### PR TITLE
disambiguate distance() calls

### DIFF
--- a/src/nfa/limex_compile.cpp
+++ b/src/nfa/limex_compile.cpp
@@ -980,7 +980,7 @@ u32 addSquashMask(const build_info &args, const NFAVertex &v,
     // see if we've already seen it, otherwise add a new one.
     auto it = find(squash.begin(), squash.end(), sit->second);
     if (it != squash.end()) {
-        return verify_u32(distance(squash.begin(), it));
+        return verify_u32(std::distance(squash.begin(), it));
     }
     u32 idx = verify_u32(squash.size());
     squash.push_back(sit->second);
@@ -1007,7 +1007,7 @@ u32 addReports(const flat_set<ReportID> &r, vector<ReportID> &reports,
     auto it = search(begin(reports), end(reports), begin(my_reports),
                      end(my_reports));
     if (it != end(reports)) {
-        u32 offset = verify_u32(distance(begin(reports), it));
+        u32 offset = verify_u32(std::distance(begin(reports), it));
         DEBUG_PRINTF("reusing found report list at %u\n", offset);
         return offset;
     }


### PR DESCRIPTION
This change makes Hyperscan support compilation with Boost 1.68.

Without this change, compiling Hyperscan with Boost 1.68 fails like this:
hyperscan-5.0.0\src\nfa\limex_compile.cpp(983): error C2668: 'boost::iterators::distance_adl_barrier::distance': ambiguous call to overloaded function
include\boost/iterator/distance.hpp(49): note: could be 'int boost::iterators::distance_adl_barrier::distance<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>(SinglePassIterator,SinglePassIterator)' [found using argument-dependent lookup]
        with
        [
            _Ty=ue2::NFAStateSet,
            SinglePassIterator=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<ue2::NFAStateSet>>>
        ]
include\xutility(1193): note: or       'int std::distance<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>>(_InIt,_InIt)'
        with
        [
            _Ty=ue2::NFAStateSet,
            _InIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<ue2::NFAStateSet>>>
        ]
hyperscan-5.0.0\src\nfa\limex_compile.cpp(983): note: while trying to match the argument list '(std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>, std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>)'
        with
        [
            _Ty=ue2::NFAStateSet
        ]
hyperscan-5.0.0\src\nfa\limex_compile.cpp(983): error C2672: 'ue2::verify_u32': no matching overloaded function found