### PR TITLE
This is a simple fix for compilation issues related to new boost libraries

### DIFF
--- a/src/nfa/limex_compile.cpp
+++ b/src/nfa/limex_compile.cpp
@@ -980,7 +980,7 @@ u32 addSquashMask(const build_info &args, const NFAVertex &v,
     // see if we've already seen it, otherwise add a new one.
     auto it = find(squash.begin(), squash.end(), sit->second);
     if (it != squash.end()) {
-        return verify_u32(distance(squash.begin(), it));
+        return verify_u32(std::distance(squash.begin(), it));
     }
     u32 idx = verify_u32(squash.size());
     squash.push_back(sit->second);


### PR DESCRIPTION
This is a simple fix for compilation issue related to new version of the boost libraries.

1. What I have done:

Explicitly use std::distance instead of distance to fix the compilation error (see below)

2. Compilation error

I got below compilation errors in both Mac and Linux machines

> [ 44%] Building CXX object CMakeFiles/hs_compile.dir/src/nfa/shengcompile.cpp.o
> [ 45%] Building CXX object CMakeFiles/hs_compile.dir/src/nfa/shufticompile.cpp.o
> [ 45%] Building CXX object CMakeFiles/hs_compile.dir/src/nfa/tamaramacompile.cpp.o
> /home/hdang/working/hyperscan/src/nfa/limex_compile.cpp: In function 'u32 ue2::{anonymous}::addSquashMask(const ue2::{anonymous}::build_info&, const NFAVertex&, std::vector<boost::dynamic_bitset<> >&)':
> /home/hdang/working/hyperscan/src/nfa/limex_compile.cpp:983:54: error: call of overloaded 'distance(std::vector<boost::dynamic_bitset<> >::iterator, __gnu_cxx::__normal_iterator<boost::dynamic_bitset<>*, std::vector<boost::dynamic_bitset<> > >&)' is ambiguous
>          return verify_u32(distance(squash.begin(), it));
>                                                       ^
> In file included from /home/hdang/.linuxbrew/Cellar/gcc/5.5.0_4/include/c++/5.5.0/bits/stl_algobase.h:66:0,
>                  from /home/hdang/.linuxbrew/Cellar/gcc/5.5.0_4/include/c++/5.5.0/bits/char_traits.h:39,
>                  from /home/hdang/.linuxbrew/Cellar/gcc/5.5.0_4/include/c++/5.5.0/string:40,
>                  from /home/hdang/working/hyperscan/src/nfa/nfa_kind.h:40,
>                  from /home/hdang/working/hyperscan/src/nfagraph/ng_holder.h:41,
>                  from /home/hdang/working/hyperscan/src/nfa/limex_compile.h:37,
>                  from /home/hdang/working/hyperscan/src/nfa/limex_compile.cpp:34:
> /home/hdang/.linuxbrew/Cellar/gcc/5.5.0_4/include/c++/5.5.0/bits/stl_iterator_base_funcs.h:114:5: note: candidate: typename std::iterator_traits<_Iterator>::difference_type std::distance(_InputIterator, _InputIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<boost::dynamic_bitset<>*, std::vector<boost::dynamic_bitset<> > >; typename std::iterator_traits<_Iterator>::difference_type = long int]
>      distance(_InputIterator __first, _InputIterator __last)
>      ^
> In file included from /home/hdang/working/3p/include/boost/range/distance.hpp:18:0,
>                  from /home/hdang/working/3p/include/boost/range/functions.hpp:21,
>                  from /home/hdang/working/3p/include/boost/range/iterator_range_core.hpp:38,
>                  from /home/hdang/working/3p/include/boost/range/iterator_range.hpp:13,
>                  from /home/hdang/working/hyperscan/src/util/graph_range.h:54,
>                  from /home/hdang/working/hyperscan/src/util/ue2_graph.h:33,
>                  from /home/hdang/working/hyperscan/src/nfagraph/ng_holder.h:44,
>                  from /home/hdang/working/hyperscan/src/nfa/limex_compile.h:37,
>                  from /home/hdang/working/hyperscan/src/nfa/limex_compile.cpp:34:
> /home/hdang/working/3p/include/boost/iterator/distance.hpp:49:9: note: candidate: typename boost::iterators::iterator_difference<Iterator>::type boost::iterators::distance_adl_barrier::distance(SinglePassIterator, SinglePassIterator) [with SinglePassIterator = __gnu_cxx::__normal_iterator<boost::dynamic_bitset<>*, std::vector<boost::dynamic_bitset<> > >; typename boost::iterators::iterator_difference<Iterator>::type = long int]
>          distance(SinglePassIterator first, SinglePassIterator last)
>          ^
> [ 45%] Building CXX object CMakeFiles/hs_compile.dir/src/nfa/trufflecompile.cpp.o
> make[2]: *** [CMakeFiles/hs_compile.dir/src/nfa/limex_compile.cpp.o] Error 1
> make[2]: *** Waiting for unfinished jobs....
> [ 45%] Building CXX object CMakeFiles/hs_compile.dir/src/nfagraph/ng.cpp.o
> make[1]: *** [CMakeFiles/hs_compile.dir/all] Error 2
> make: *** [all] Error 2
> 
> Compilation exited abnormally with code 2 at Mon Dec 17 10:17:54
> 

3. Unit test results

> [----------] 4 tests from Som/SomTest
> [ RUN      ] Som/SomTest.PastHorizon/0
> [       OK ] Som/SomTest.PastHorizon/0 (2 ms)
> [ RUN      ] Som/SomTest.PastHorizon/1
> [       OK ] Som/SomTest.PastHorizon/1 (1034 ms)
> [ RUN      ] Som/SomTest.NearHorizon/0
> [       OK ] Som/SomTest.NearHorizon/0 (2 ms)
> [ RUN      ] Som/SomTest.NearHorizon/1
> [       OK ] Som/SomTest.NearHorizon/1 (1034 ms)
> [----------] 4 tests from Som/SomTest (2072 ms total)
> 
> [----------] Global test environment tear-down
> [==========] 3750 tests from 32 test cases ran. (216216 ms total)
> [  PASSED  ] 3750 tests.