### PR TITLE
cmake: we use SSSE3, so correctly pass it to the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,8 +231,8 @@ else()
     endif(OPTIMISE)
 
     # set compiler flags - more are tested and added later
-    set(EXTRA_C_FLAGS "${OPT_C_FLAG} -std=c99 -Wall -Wextra -Wshadow -Wcast-qual -fno-strict-aliasing")
-    set(EXTRA_CXX_FLAGS "${OPT_CXX_FLAG} -std=c++11 -Wall -Wextra -Wshadow -Wswitch -Wreturn-type -Wcast-qual -Wno-deprecated -Wnon-virtual-dtor -fno-strict-aliasing")
+    set(EXTRA_C_FLAGS "${OPT_C_FLAG} -std=c99 -Wall -Wextra -Wshadow -Wcast-qual -fno-strict-aliasing -mssse3")
+    set(EXTRA_CXX_FLAGS "${OPT_CXX_FLAG} -std=c++11 -Wall -Wextra -Wshadow -Wswitch -Wreturn-type -Wcast-qual -Wno-deprecated -Wnon-virtual-dtor -fno-strict-aliasing -mssse3")
 
     if (NOT RELEASE_BUILD)
         # -Werror is most useful during development, don't potentially break


### PR DESCRIPTION
Fixes failing SSSE3 test on my machine (tested on Gentoo).

Signed-off-by: David Heidelberg <david@ixit.cz>