### PR TITLE
stream: added a public API to detect stream exhaustion.

### DIFF
--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -91,8 +91,6 @@ CREATE_DISPATCH(hs_error_t, hs_scan_stream, hs_stream_t *id, const char *data,
                 unsigned int length, unsigned int flags, hs_scratch_t *scratch,
                 match_event_handler onEvent, void *ctxt);
 
-CREATE_DISPATCH(hs_error_t, hs_is_stream_exhausted, hs_stream_t *id, int *exhausted);
-
 CREATE_DISPATCH(hs_error_t, hs_close_stream, hs_stream_t *id,
                 hs_scratch_t *scratch, match_event_handler onEvent, void *ctxt);
 
@@ -113,6 +111,8 @@ CREATE_DISPATCH(hs_error_t, hs_reset_stream, hs_stream_t *id,
 CREATE_DISPATCH(hs_error_t, hs_reset_and_copy_stream, hs_stream_t *to_id,
                 const hs_stream_t *from_id, hs_scratch_t *scratch,
                 match_event_handler onEvent, void *context);
+
+CREATE_DISPATCH(hs_error_t, hs_is_stream_exhausted, hs_stream_t *id, int *exhausted);
 
 CREATE_DISPATCH(hs_error_t, hs_serialize_database, const hs_database_t *db,
                 char **bytes, size_t *length);

--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -91,6 +91,8 @@ CREATE_DISPATCH(hs_error_t, hs_scan_stream, hs_stream_t *id, const char *data,
                 unsigned int length, unsigned int flags, hs_scratch_t *scratch,
                 match_event_handler onEvent, void *ctxt);
 
+CREATE_DISPATCH(hs_error_t, hs_is_stream_exhausted, hs_stream_t *id, int *exhausted);
+
 CREATE_DISPATCH(hs_error_t, hs_close_stream, hs_stream_t *id,
                 hs_scratch_t *scratch, match_event_handler onEvent, void *ctxt);
 

--- a/src/hs_runtime.h
+++ b/src/hs_runtime.h
@@ -191,22 +191,6 @@ hs_error_t HS_CDECL hs_scan_stream(hs_stream_t *id, const char *data,
                                    match_event_handler onEvent, void *ctxt);
 
 /**
- * Get whether it has been determined that it is not possible for this stream
- * to raise any more matches (i.e. the stream is exhausted).
- *
- * @param id
- *      The stream ID (returned by @ref hs_open_stream()).
- *
- * @param exhausted
- *      Returns an integer value. The value would be 0 if the stream is not
- *      exhausted, otherwise the value would be a non-zero integer.
- *
- * @return
- *      @ref HS_SUCCESS on success, other values on failure.
- */
-hs_error_t HS_CDECL hs_is_stream_exhausted(hs_stream_t *id, int *exhausted);
-
-/**
  * Close a stream.
  *
  * This function completes matching on the given stream and frees the memory
@@ -456,6 +440,22 @@ hs_error_t HS_CDECL hs_reset_and_expand_stream(hs_stream_t *to_stream,
                                                hs_scratch_t *scratch,
                                                match_event_handler onEvent,
                                                void *context);
+
+/**
+ * Get whether it has been determined that it is not possible for this stream
+ * to raise any more matches (i.e. the stream is exhausted).
+ *
+ * @param id
+ *      The stream ID (returned by @ref hs_open_stream()).
+ *
+ * @param exhausted
+ *      Returns an integer value. The value would be 0 if the stream is not
+ *      exhausted, otherwise the value would be a non-zero integer.
+ *
+ * @return
+ *      @ref HS_SUCCESS on success, other values on failure.
+ */
+hs_error_t HS_CDECL hs_is_stream_exhausted(hs_stream_t *id, int *exhausted);
 
 /**
  * The block (non-streaming) regular expression scanner.

--- a/src/hs_runtime.h
+++ b/src/hs_runtime.h
@@ -191,6 +191,22 @@ hs_error_t HS_CDECL hs_scan_stream(hs_stream_t *id, const char *data,
                                    match_event_handler onEvent, void *ctxt);
 
 /**
+ * Get whether it has been determined that it is not possible for this stream
+ * to raise any more matches (i.e. the stream is exhausted).
+ *
+ * @param id
+ *      The stream ID (returned by @ref hs_open_stream()).
+ *
+ * @param exhausted
+ *      Returns an integer value. The value would be 0 if the stream is not
+ *      exhausted, otherwise the value would be a non-zero integer.
+ *
+ * @return
+ *      @ref HS_SUCCESS on success, other values on failure.
+ */
+hs_error_t HS_CDECL hs_is_stream_exhausted(hs_stream_t *id, int *exhausted);
+
+/**
  * Close a stream.
  *
  * This function completes matching on the given stream and frees the memory

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -986,25 +986,6 @@ hs_error_t HS_CDECL hs_scan_stream(hs_stream_t *id, const char *data,
 }
 
 HS_PUBLIC_API
-hs_error_t HS_CDECL hs_is_stream_exhausted(hs_stream_t *id, int *exhausted) {
-    if (unlikely(!id || !exhausted)) {
-        return HS_INVALID;
-    }
-
-    char *state = getMultiState(id);
-
-    u8 status = getStreamStatus(state);
-
-    if (status & STATUS_EXHAUSTED) {
-        *exhausted = 1;
-    } else {
-        *exhausted = 0;
-    }
-
-    return HS_SUCCESS;
-}
-
-HS_PUBLIC_API
 hs_error_t HS_CDECL hs_close_stream(hs_stream_t *id, hs_scratch_t *scratch,
                                     match_event_handler onEvent,
                                     void *context) {
@@ -1291,4 +1272,23 @@ hs_error_t HS_CDECL hs_reset_and_expand_stream(hs_stream_t *to_stream,
     } else {
         return HS_INVALID;
     }
+}
+
+HS_PUBLIC_API
+hs_error_t HS_CDECL hs_is_stream_exhausted(hs_stream_t *id, int *exhausted) {
+    if (unlikely(!id || !exhausted)) {
+        return HS_INVALID;
+    }
+
+    char *state = getMultiState(id);
+
+    u8 status = getStreamStatus(state);
+
+    if (status & STATUS_EXHAUSTED) {
+        *exhausted = 1;
+    } else {
+        *exhausted = 0;
+    }
+
+    return HS_SUCCESS;
 }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -986,6 +986,25 @@ hs_error_t HS_CDECL hs_scan_stream(hs_stream_t *id, const char *data,
 }
 
 HS_PUBLIC_API
+hs_error_t HS_CDECL hs_is_stream_exhausted(hs_stream_t *id, int *exhausted) {
+    if (unlikely(!id || !exhausted)) {
+        return HS_INVALID;
+    }
+
+    char *state = getMultiState(id);
+
+    u8 status = getStreamStatus(state);
+
+    if (status & STATUS_EXHAUSTED) {
+        *exhausted = 1;
+    } else {
+        *exhausted = 0;
+    }
+
+    return HS_SUCCESS;
+}
+
+HS_PUBLIC_API
 hs_error_t HS_CDECL hs_close_stream(hs_stream_t *id, hs_scratch_t *scratch,
                                     match_event_handler onEvent,
                                     void *context) {

--- a/unit/hyperscan/stream_op.cpp
+++ b/unit/hyperscan/stream_op.cpp
@@ -823,4 +823,70 @@ TEST(StreamUtil, StreamAllocUsage) {
     ASSERT_EQ(0, alloc3_called);
 }
 
+TEST(StreamUtil, is_exhausted1) {
+    hs_error_t err;
+    hs_scratch_t *scratch = nullptr;
+    hs_database_t *db = buildDBAndScratch("^bar", 0, 0, HS_MODE_STREAM,
+                                          &scratch);
+
+    hs_stream_t *stream = nullptr;
+
+    CallBackContext c;
+
+    err = hs_open_stream(db, 0, &stream);
+    ASSERT_EQ(HS_SUCCESS, err);
+    ASSERT_TRUE(stream != nullptr);
+
+    int exhausted = 0;
+    err = hs_is_stream_exhausted(stream, &exhausted);
+    ASSERT_EQ(HS_SUCCESS, err);
+    ASSERT_EQ(0, exhausted);
+
+    err = hs_scan_stream(stream, data1, sizeof(data1), 0, scratch, record_cb,
+                         (void *)&c);
+    ASSERT_EQ(HS_SUCCESS, err);
+
+    err = hs_is_stream_exhausted(stream, &exhausted);
+    ASSERT_EQ(HS_SUCCESS, err);
+    ASSERT_TRUE(exhausted != 0);
+
+    hs_close_stream(stream, scratch, nullptr, nullptr);
+    err = hs_free_scratch(scratch);
+    ASSERT_EQ(HS_SUCCESS, err);
+    hs_free_database(db);
+}
+
+TEST(StreamUtil, is_exhausted2) {
+    hs_error_t err;
+    hs_scratch_t *scratch = nullptr;
+    hs_database_t *db = buildDBAndScratch("^foo", 0, 0, HS_MODE_STREAM,
+                                          &scratch);
+
+    hs_stream_t *stream = nullptr;
+
+    CallBackContext c;
+
+    err = hs_open_stream(db, 0, &stream);
+    ASSERT_EQ(HS_SUCCESS, err);
+    ASSERT_TRUE(stream != nullptr);
+
+    int exhausted = 0;
+    err = hs_is_stream_exhausted(stream, &exhausted);
+    ASSERT_EQ(HS_SUCCESS, err);
+    ASSERT_EQ(0, exhausted);
+
+    err = hs_scan_stream(stream, data1, sizeof(data1), 0, scratch, record_cb,
+                         (void *)&c);
+    ASSERT_EQ(HS_SUCCESS, err);
+
+    err = hs_is_stream_exhausted(stream, &exhausted);
+    ASSERT_EQ(HS_SUCCESS, err);
+    ASSERT_TRUE(exhausted != 0);
+
+    hs_close_stream(stream, scratch, nullptr, nullptr);
+    err = hs_free_scratch(scratch);
+    ASSERT_EQ(HS_SUCCESS, err);
+    hs_free_database(db);
+}
+
 }


### PR DESCRIPTION
In some senarios, the application has to detect whether a stream is exhausted so that the application can do some actions when all patterns are either matched or can never be matched.

For example, a firewall program may use certain patterns to detect the type of a TCP stream, it must do something if the type of the TCP stream can't be detected. In this senario, the firewall program has to use the API to detect stream exhaustion.

API code example:
```
hs_stream_t *stream = nullptr;
... (Code to open the stream and do some scanning)...
int exhausted = 0;
if (hs_is_stream_exhausted(stream, &exhausted) != HS_SUCCESS) {
    ... (Error handling) ...
}
if (exhausted) {
    printf("The stream is exhausted.");
} else {
    printf("The stream is NOT exhausted.");
}
```

