### PR TITLE
Avoid array-bounds error when debug/fortify enabled

### DIFF
--- a/util/expression_path.h
+++ b/util/expression_path.h
@@ -56,9 +56,8 @@ std::string inferExpressionPath(const std::string &sigFile) {
     // POSIX variant.
 
     // dirname() may modify its argument, so we must make a copy.
-    std::vector<char> path(sigFile.size() + 1);
-    memcpy(path.data(), sigFile.c_str(), sigFile.size());
-    path[sigFile.size()] = 0; // ensure null termination.
+    std::vector<char> path(sigFile.begin(), sigFile.end());
+    path.push_back(0); // ensure null termination.
 
     std::string rv = dirname(path.data());
 #else


### PR DESCRIPTION
This code causes GCC to error out due to a bounds error with the following set

	-D_GLIBCXX_DEBUG
	-D_FORTIFY_SOURCE=2

The solution is to copy via iterator.