### PR TITLE
Fix uninitialized use of scatter_unit_uX due to padding

### DIFF
--- a/src/util/multibit_build.cpp
+++ b/src/util/multibit_build.cpp
@@ -192,11 +192,11 @@ vector<mmbit_sparse_iter> mmbBuildSparseIterator(const vector<u32> &bits,
 template<typename T>
 static
 void add_scatter(vector<T> *out, u32 offset, u64a mask) {
-    T su;
+    out->emplace_back();
+    T &su = out->back();
     memset(&su, 0, sizeof(su));
     su.offset = offset;
     su.val = mask;
-    out->push_back(su);
     DEBUG_PRINTF("add %llu at offset %u\n", mask, offset);
 }
 


### PR DESCRIPTION
These non-packed structures are placed into a std::vector.  Later, they
contents of the vector are memcpy'd and the CRC of this space is taken.
Some compilers will zero the struct padding but GCC8.2 with -O2 at least
will not.  This means that the CRC is based on uninitialized memory.

Since it is expected that these bytes will be memcpy'd, zero in place once
they're in the std::vector.

Found by Valgrind.

Q.v. Issue #148