### PR TITLE
BUGFIX: fix Numerical result out of range error

### DIFF
--- a/src/fdr/fdr_compile.cpp
+++ b/src/fdr/fdr_compile.cpp
@@ -282,8 +282,8 @@ const array<double, 100> Scorer::count_lut{{
 }};
 
 const array<double, 9> Scorer::len_lut{{
-    pow(0, -3.0), pow(1, -3.0), pow(2, -3.0), pow(3, -3.0), pow(4, -3.0),
-    pow(5, -3.0), pow(6, -3.0), pow(7, -3.0), pow(8, -3.0)}};
+    0, pow(1, -3.0), pow(2, -3.0), pow(3, -3.0), pow(4, -3.0),
+       pow(5, -3.0), pow(6, -3.0), pow(7, -3.0), pow(8, -3.0)}};
 
 /**
  * Returns true if the two given literals should be placed in the same chunk as


### PR DESCRIPTION
Fix Error errno=34,  fix Numerical result out of range error
issue: https://github.com/intel/hyperscan/issues/155