### PR TITLE
tools: hscollider FTBS in alpine linux

### DIFF
--- a/tools/hscollider/sig.cpp
+++ b/tools/hscollider/sig.cpp
@@ -42,7 +42,10 @@
 
 #ifdef HAVE_BACKTRACE
 #include <execinfo.h>
-#include <unistd.h>
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h> // for _exit
 #endif
 
 #define BACKTRACE_BUFFER_SIZE 200


### PR DESCRIPTION
alpine uses musl instead of glibc and therefore doesn't have backtrace()
as part of its libc.

POSIX mandates that _exit() be defined through unistd.h which used to be
included together with execinfo.h when backtrace() was detected and
therefore happened to build fine for Linux or FreeBSD (when using
libexecinfo from the system or ports).

since there was a macro already defined to test for unistd.h use that
instead and decouple this dependency, so that the code could be built
even when no backtrace() is provided by the system (as is also expected in OpenBSD)