### PR TITLE
Improves ergonomics when pkg-config is missing and updates docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,11 @@ include (GNUInstallDirs)
 include (${CMAKE_MODULE_PATH}/platform.cmake)
 include (${CMAKE_MODULE_PATH}/ragel.cmake)
 
-find_package(PkgConfig QUIET)
+find_package(PkgConfig)
+
+if(NOT PkgConfig_FOUND)
+    message(STATUS "Could not find pkg-config. Will not generate pkg-config metadata for libhs.")
+endif()
 
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Default build type 'Release with debug info'")

--- a/cmake/pcre.cmake
+++ b/cmake/pcre.cmake
@@ -52,10 +52,16 @@ if (PCRE_BUILD_SOURCE)
 else ()
     # pkgconf should save us
     find_package(PkgConfig)
+    if (NOT PkgConfig_FOUND)
+        message(STATUS "pkg-config was not found. This is required to dynamically link libpcre.")
+        return ()
+        # first check for sqlite on the system
+    endif ()
+
     pkg_check_modules(PCRE libpcre>=${PCRE_REQUIRED_VERSION})
     if (PCRE_FOUND)
         set(CORRECT_PCRE_VERSION TRUE)
-        message(STATUS "PCRE version ${PCRE_REQUIRED_VERSION} or above")
+        message(STATUS "Found PCRE version ${PCRE_REQUIRED_VERSION} or above")
     else ()
         message(STATUS "PCRE version ${PCRE_REQUIRED_VERSION} or above not found")
         return ()

--- a/cmake/sqlite3.cmake
+++ b/cmake/sqlite3.cmake
@@ -5,10 +5,14 @@
 option(SQLITE_PREFER_STATIC "Build sqlite3 statically instead of using an installed lib" OFF)
 
 if(NOT WIN32 AND NOT SQLITE_PREFER_STATIC)
-find_package(PkgConfig QUIET)
+    find_package(PkgConfig)
 
-# first check for sqlite on the system
-pkg_check_modules(SQLITE3 sqlite3)
+    if(NOT PkgConfig_FOUND)
+        message(STATUS "pkg-config was not found. This is required to dynamically link sqlite3.")
+    else()
+        # first check for sqlite on the system
+        pkg_check_modules(SQLITE3 sqlite3)
+    endif()
 endif()
 
 if (NOT SQLITE3_FOUND)

--- a/doc/dev-reference/getting_started.rst
+++ b/doc/dev-reference/getting_started.rst
@@ -129,6 +129,27 @@ system (e.g. Debian/Ubuntu/RedHat packages, FreeBSD ports, etc). However,
 ensure that the correct version is present. As for Windows, in order to have
 Ragel, you may use Cygwin to build it from source.
 
+Optional Dependencies
+---------------------
+
+The following dependencies are optional. Their required versions are listed
+in the table below.
+
+* pkg-config will be used to generate pkg-config metadata for ``libhs``.
+  Additionally it must be installed to dynamically link Sqlite and PCRE,
+  which are build the ``hsbench`` and ``hscollider``.
+* Sqlite is required to build the ``hsbench`` benchmarking tool.
+* PCRE is required to build the ``hscollider`` tool.
+
+======================================================================= =========== ====================================
+Dependency                                                              Version     Notes
+======================================================================= =========== ====================================
+`pkg-config <https://www.freedesktop.org/wiki/Software/pkg-config/>`_   N/A
+`Sqlite <https://www.sqlite.org/index.html>`_                           >=3         Versions 3.8.7-3.8.10 are **not**
+                                                                                    compatible.
+`PCRE <https://www.pcre.org/>`_                                         >=8.41
+======================================================================= =========== ====================================
+
 Boost Headers
 -------------
 


### PR DESCRIPTION
Fixes #135 

`pkg-config` is needed to build `hsbench` and `hscollider` as it's used to dynamically link sqlite and libpcre however this is not outlined by the build process nor in the dev docs (outlined in #135).

This PR includes two changes:

1. I've updated the CMake files to print an explicit log message when `pkg-config` is missing
2. I've added a section to the `Getting Started` section of the docs that outlines the optional dependencies and what they are used for.

---

**Before**

```
$ skathi ~/w/sgg-hyperscan git:master ❯❯❯ cmake -G Ninja
...
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- PCRE version 8.41 or above not found
-- PCRE 8.41 or above not found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE
-- looking for sqlite3 in source tree
--   no sqlite3 in source tree
-- sqlite3 not found, not building hsbench
-- PCRE 8.41 not found, not building hscollider
```

**After**

```
$ skathi ~/w/sgg-hyperscan git:dep-docs ❯❯❯ cmake -G Ninja
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Could not find pkg-config. Will not generate pkg-config metadata for libhs.
...
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- pkg-config was not found. This is required to dynamically link libpcre.
-- PCRE 8.41 or above not found
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- pkg-config was not found. This is required to dynamically link sqlite3.
-- looking for sqlite3 in source tree
--   no sqlite3 in source tree
-- sqlite3 not found, not building hsbench
-- PCRE 8.41 not found, not building hscollider
```