### PR TITLE
Fix error in db_check_platform function

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -114,8 +114,8 @@ hs_error_t HS_CDECL hs_serialize_database(const hs_database_t *db, char **bytes,
 static
 hs_error_t db_check_platform(const u64a p) {
     if (p != hs_current_platform
-        && p != hs_current_platform_no_avx2
-        && p != hs_current_platform_no_avx512) {
+        && p != (hs_current_platform | hs_current_platform_no_avx2)
+        && p != (hs_current_platform | hs_current_platform_no_avx512)) {
         return HS_DB_PLATFORM_ERROR;
     }
     // passed all checks


### PR DESCRIPTION
There seems to be an error in `db_check_platform` function. When database is compiled on machine with AVX2, but without AVX512, database platform features bitmask equals to `HS_PLATFORM_NOAVX512`. As this is equal to `hs_current_platform_no_avx512` constant, such a database passes  `db_check_platform` check on any machine, including ones without AVX2 support.

Pull request fixes this error.