### PR TITLE
teddy: always initialize variable

### DIFF
--- a/src/fdr/teddy_runtime_common.h
+++ b/src/fdr/teddy_runtime_common.h
@@ -348,7 +348,7 @@ static really_inline
 m512 vectoredLoad512(m512 *p_mask, const u8 *ptr, const size_t start_offset,
                      const u8 *lo, const u8 *hi, const u8 *hbuf, size_t hlen,
                      const u32 nMasks) {
-    m512 val;
+    m512 val = set64x8(0x0);
 
     uintptr_t copy_start;
     uintptr_t copy_len;


### PR DESCRIPTION
Hyperscan fails to build with Clang with the "sometimes-unitialized" check switched on:

```
src/fdr/teddy_runtime_common.h:359:13: error: variable 'val' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
        if (avail >= 64) {
            ^~~~~~~~~~~
src/fdr/teddy_runtime_common.h:388:27: note: uninitialized use occurs here
    val = loadu_mask_m512(val, j, ptr);
                          ^~~
src/fdr/teddy_runtime_common.h:359:9: note: remove the 'if' if its condition is always true
        if (avail >= 64) {
        ^~~~~~~~~~~~~~~~~
src/fdr/teddy_runtime_common.h:351:5: note: variable 'val' is declared here
    m512 val;
    ^
```
Always initialize `val` to zero upon declaration.

NOTE: this PR fixes the build failure only. I don't know if initializing `val` to zero is harmless.