### PR TITLE
Fix debug output

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -1088,6 +1088,10 @@ hs_error_t HS_CDECL hs_stream_size(const hs_database_t *db,
 // perusal.
 static UNUSED
 void dumpData(const char *data, size_t len) {
+    if (unlikely(!data)) {
+        DEBUG_PRINTF("data is NULL");
+        return;
+    }
     DEBUG_PRINTF("BUFFER:");
     for (size_t i = 0; i < len; i++) {
         u8 c = data[i];


### PR DESCRIPTION
Unit tests are failing if build with `-DCMAKE_BUILD_TYPE=Debug -DDEBUG_OUTPUT=ON` because of `NULL` pointer dereferencing in `DumpDate` function in src/runtime.c. [Here](https://github.com/intel/hyperscan/files/6511870/output.txt) is address sanitizer output. So I suggest adding the following lines at the beginning of `DumpData`:

```c
if (unlikely(!data)) {
    DEBUG_PRINTF("data is NULL");
    return;
}
```