### PR TITLE
Fix segfaults on allocation failure

### DIFF
--- a/src/util/alloc.h
+++ b/src/util/alloc.h
@@ -76,7 +76,11 @@ public:
 
     T *allocate(std::size_t size) const {
         size_t alloc_size = size * sizeof(T);
-        return static_cast<T *>(aligned_malloc_internal(alloc_size, N));
+        T *ptr = static_cast<T *>(aligned_malloc_internal(alloc_size, N));
+        if (!ptr) {
+            throw std::bad_alloc();
+        }
+        return ptr;
     }
 
     void deallocate(T *x, std::size_t) const noexcept {


### PR DESCRIPTION
Throw std::bad_alloc instead of returning nullptr from ue2::AlignedAllocator. Allocators for STL containers are expected never to return with an invalid pointer, and instead must throw on failure. Violating this expectation can lead to invalid pointer dereferences.

Fixes https://github.com/intel/hyperscan/issues/317.