### PR TITLE
Fix word boundary assertions under C++20

### DIFF
--- a/src/rose/rose_graph.h
+++ b/src/rose/rose_graph.h
@@ -112,7 +112,7 @@ struct LeftEngInfo {
     }
     size_t hash() const;
     void reset(void);
-    operator bool() const;
+    explicit operator bool() const;
     bool tracksSom() const { return !!haig; }
 };
 
@@ -133,7 +133,7 @@ struct RoseSuffixInfo {
     bool operator<(const RoseSuffixInfo &b) const;
     size_t hash() const;
     void reset(void);
-    operator bool() const { return graph || castle || haig || rdfa || tamarama; }
+    explicit operator bool() const { return graph || castle || haig || rdfa || tamarama; }
 };
 
 /** \brief Properties attached to each Rose graph vertex. */

--- a/src/util/ue2_graph.h
+++ b/src/util/ue2_graph.h
@@ -176,7 +176,7 @@ public:
     vertex_descriptor() : p(nullptr), serial(0) {}
     explicit vertex_descriptor(vertex_node *pp) : p(pp), serial(pp->serial) {}
 
-    operator bool() const { return p; }
+    explicit operator bool() const { return p; }
     bool operator<(const vertex_descriptor b) const {
         if (p && b.p) {
             /* no vertices in the same graph can have the same serial */


### PR DESCRIPTION
In C++20 with [P1614R2](https://wg21.link/P1614R2) implemented, zero-width assertions `\b` and `\B` do not work. For example, the following code fails with "Pattern can never match":
```cpp
#include <hyperscan/src/hs.h>

#include <cstdio>


int main() {
    hs_compile_error_t* err = nullptr;
    hs_database_t* db = nullptr;
    hs_platform_info_t platform;
    hs_populate_platform(&platform);
    hs_error_t res = hs_compile("foo\\b", 0, HS_MODE_BLOCK, &platform, &db, &err);
    if (res != HS_SUCCESS) {
        printf("Error: %s\n", err->message);
    }
    hs_free_database(db);
}
```

This is caused by breaking change in `std::pair` comparison operators (after [P1614R2](https://wg21.link/P1614R2) `std::pair` uses `operator<=>`). The spaceship operator prefers implicit conversion to `bool`, if exists:
https://godbolt.org/z/xnPreToW4
https://godbolt.org/z/T4cKEPrTf

So nearly all values of type `std::pair<ue2::graph_detail::vertex_descriptor, ue2::graph_detail::vertex_descriptor>` compare equal: https://github.com/intel/hyperscan/blob/master/src/util/ue2_graph.h#L179-L188, so `edge_cache_t` is malformed: https://github.com/intel/hyperscan/blob/master/src/compiler/asserts.cpp#L284-L288, and the NFA graph after [removeAssertVertices](https://github.com/intel/hyperscan/blob/master/src/compiler/asserts.cpp#L269) becomes disconnected.

The fix is simple: just mark `operator bool()` as `explicit`.
