### PR TITLE
fix build with glibc-2.34

### DIFF
--- a/tools/hscollider/sig.cpp
+++ b/tools/hscollider/sig.cpp
@@ -38,6 +38,7 @@
 
 #if defined(HAVE_SIGACTION) || defined(_WIN32)
 #include <signal.h>
+#define STACK_SIZE 8192
 #endif
 
 #ifdef HAVE_BACKTRACE
@@ -175,7 +176,7 @@ void installSignalHandler(void) {
 }
 
 #ifdef HAVE_SIGALTSTACK
-static TLS_VARIABLE char alt_stack_loc[SIGSTKSZ];
+static TLS_VARIABLE char alt_stack_loc[STACK_SIZE];
 #endif
 
 void setSignalStack(void) {
@@ -187,7 +188,7 @@ void setSignalStack(void) {
     stack_t alt_stack;
     memset(&alt_stack, 0, sizeof(alt_stack));
     alt_stack.ss_flags = 0;
-    alt_stack.ss_size = SIGSTKSZ;
+    alt_stack.ss_size = STACK_SIZE;
     alt_stack.ss_sp = alt_stack_loc;
     if (!sigaltstack(&alt_stack, nullptr)) {
         act.sa_flags |= SA_ONSTACK;

--- a/tools/hscollider/sig.cpp
+++ b/tools/hscollider/sig.cpp
@@ -38,7 +38,7 @@
 
 #if defined(HAVE_SIGACTION) || defined(_WIN32)
 #include <signal.h>
-#define STACK_SIZE 8192
+#define STACK_SIZE 8192 // linux kernel default stack size for x86
 #endif
 
 #ifdef HAVE_BACKTRACE


### PR DESCRIPTION
SIGTSKSZ is no long a constant after glibc 2.34, hardcode STACK_SIZE to fix this.
https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html