### PR TITLE
Remove unused boost version header

### DIFF
--- a/include/boost-patched/graph/reverse_graph.hpp
+++ b/include/boost-patched/graph/reverse_graph.hpp
@@ -1,8 +1,6 @@
 #ifndef REVERSE_GRAPH_PATCHED_H_
 #define REVERSE_GRAPH_PATCHED_H_
 
-#include <boost/version.hpp>
-
 #include <boost/graph/reverse_graph.hpp>
 
 #if defined(BOOST_REVGRAPH_PATCH)


### PR DESCRIPTION
It appears this header is not utilized within this file and does not appear to affect building hyperscan. This also removes a potential recompile path when the boost version changes[1].

[1] https://github.com/boostorg/config/blob/develop/include/boost/version.hpp#L13

Signed-off-by: Ben Magistro <koncept1@gmail.com>