### PR TITLE
fix LBR_NFA_VSHUF compilation errors

### DIFF
--- a/src/nfa/nfa_dump_dispatch.cpp
+++ b/src/nfa/nfa_dump_dispatch.cpp
@@ -75,7 +75,6 @@ namespace ue2 {
         DISPATCH_CASE(LBR_NFA_VERM, LbrVerm, dbnt_func);                       \
         DISPATCH_CASE(LBR_NFA_NVERM, LbrNVerm, dbnt_func);                     \
         DISPATCH_CASE(LBR_NFA_SHUF, LbrShuf, dbnt_func);                       \
-        DISPATCH_CASE(LBR_NFA_VSHUF, LbrVShuf, dbnt_func);                     \
         DISPATCH_CASE(LBR_NFA_TRUF, LbrTruf, dbnt_func);                       \
         DISPATCH_CASE(CASTLE_NFA, Castle, dbnt_func);                          \
         DISPATCH_CASE(SHENG_NFA, Sheng, dbnt_func);                            \


### PR DESCRIPTION
It seems that LBR_NFA_VSHUF has no effect and will cause compilation errors
