### PR TITLE
Change 'move' to 'std::move' to avoid unqualified move call warnings on Clang 17+

### DIFF
--- a/chimera/ch_compile.cpp
+++ b/chimera/ch_compile.cpp
@@ -497,7 +497,7 @@ void ch_compile_multi_int(const char *const *expressions, const unsigned *flags,
         auto patternData =
             ue2::make_unique<PatternData>(myExpr, myFlags, i, myId, mode, match_limit,
                                           match_limit_recursion, platform);
-        pcres.push_back(move(patternData));
+        pcres.push_back(std::move(patternData));
         PatternData &curr = *pcres.back();
 
         if (!(myFlags & HS_FLAG_SINGLEMATCH)) {

--- a/src/fdr/fdr_compile.cpp
+++ b/src/fdr/fdr_compile.cpp
@@ -99,7 +99,7 @@ public:
                 const FDREngineDescription &eng_in,
                 bool make_small_in, const Grey &grey_in)
         : eng(eng_in), grey(grey_in), tab(eng_in.getTabSizeBytes()),
-          lits(move(lits_in)), bucketToLits(move(bucketToLits_in)),
+          lits(std::move(lits_in)), bucketToLits(std::move(bucketToLits_in)),
           make_small(make_small_in) {}
 
     bytecode_ptr<FDR> build();
@@ -505,7 +505,7 @@ map<BucketIndex, vector<LiteralIndex>> assignStringsToBuckets(
     map<BucketIndex, vector<LiteralIndex>> bucketToLits;
     size_t bucketCnt = buckets.size();
     for (size_t i = 0; i < bucketCnt; i++) {
-        bucketToLits.emplace(bucketCnt - i - 1, move(buckets[i]));
+        bucketToLits.emplace(bucketCnt - i - 1, std::move(buckets[i]));
     }
 
     return bucketToLits;
@@ -868,7 +868,7 @@ unique_ptr<HWLMProto> fdrBuildProtoInternal(u8 engType,
     auto bucketToLits = assignStringsToBuckets(lits, *des);
     addIncludedInfo(lits, des->getNumBuckets(), bucketToLits);
     auto proto =
-        ue2::make_unique<HWLMProto>(engType, move(des), lits, bucketToLits,
+        ue2::make_unique<HWLMProto>(engType, std::move(des), lits, bucketToLits,
                                     make_small);
     return proto;
 }

--- a/src/fdr/fdr_confirm_compile.cpp
+++ b/src/fdr/fdr_confirm_compile.cpp
@@ -309,7 +309,7 @@ setupFullConfs(const vector<hwlmLiteral> &lits,
             DEBUG_PRINTF("b %d sz %zu\n", b, vl.size());
             auto fc = getFDRConfirm(vl, make_small);
             totalConfirmSize += fc.size();
-            bc2Conf.emplace(b, move(fc));
+            bc2Conf.emplace(b, std::move(fc));
         }
     }
 

--- a/src/fdr/teddy_compile.cpp
+++ b/src/fdr/teddy_compile.cpp
@@ -89,7 +89,7 @@ public:
                   const TeddyEngineDescription &eng_in, bool make_small_in,
                   const Grey &grey_in)
         : eng(eng_in), grey(grey_in), lits(lits_in),
-          bucketToLits(move(bucketToLits_in)), make_small(make_small_in) {}
+          bucketToLits(std::move(bucketToLits_in)), make_small(make_small_in) {}
 
     bytecode_ptr<FDR> build();
 };
@@ -677,7 +677,7 @@ unique_ptr<HWLMProto> teddyBuildProtoHinted(
         return nullptr;
     }
 
-    return ue2::make_unique<HWLMProto>(engType, move(des), lits,
+    return ue2::make_unique<HWLMProto>(engType, std::move(des), lits,
                                        bucketToLits, make_small);
 }
 

--- a/src/hwlm/hwlm_build.cpp
+++ b/src/hwlm/hwlm_build.cpp
@@ -58,24 +58,24 @@ using namespace std;
 namespace ue2 {
 
 HWLMProto::HWLMProto(u8 engType_in, vector<hwlmLiteral> lits_in)
-    : engType(engType_in), lits(move(lits_in)) {}
+    : engType(engType_in), lits(std::move(lits_in)) {}
 
 HWLMProto::HWLMProto(u8 engType_in,
                      unique_ptr<FDREngineDescription> eng_in,
                      vector<hwlmLiteral> lits_in,
                      map<u32, vector<u32>> bucketToLits_in,
                      bool make_small_in)
-    : engType(engType_in), fdrEng(move(eng_in)), lits(move(lits_in)),
-      bucketToLits(move(bucketToLits_in)), make_small(make_small_in) {}
+    : engType(engType_in), fdrEng(std::move(eng_in)), lits(std::move(lits_in)),
+      bucketToLits(std::move(bucketToLits_in)), make_small(make_small_in) {}
 
 HWLMProto::HWLMProto(u8 engType_in,
                      unique_ptr<TeddyEngineDescription> eng_in,
                      vector<hwlmLiteral> lits_in,
                      map<u32, vector<u32>> bucketToLits_in,
                      bool make_small_in)
-    : engType(engType_in), teddyEng(move(eng_in)),
-      lits(move(lits_in)),
-      bucketToLits(move(bucketToLits_in)), make_small(make_small_in) {}
+    : engType(engType_in), teddyEng(std::move(eng_in)),
+      lits(std::move(lits_in)),
+      bucketToLits(std::move(bucketToLits_in)), make_small(make_small_in) {}
 
 HWLMProto::~HWLMProto() {}
 
@@ -133,14 +133,14 @@ bytecode_ptr<HWLM> hwlmBuild(const HWLMProto &proto, const CompileContext &cc,
         if (noodle) {
             engSize = noodle.size();
         }
-        eng = move(noodle);
+        eng = std::move(noodle);
     } else {
         DEBUG_PRINTF("building a new deal\n");
         auto fdr = fdrBuildTable(proto, cc.grey);
         if (fdr) {
             engSize = fdr.size();
         }
-        eng = move(fdr);
+        eng = std::move(fdr);
     }
 
     if (!eng) {

--- a/src/nfa/accel_dfa_build_strat.cpp
+++ b/src/nfa/accel_dfa_build_strat.cpp
@@ -128,14 +128,14 @@ void extend(const raw_dfa &rdfa, const vector<CharReach> &rev_map,
         } else {
             path pp = append(p, CharReach(), p.dest);
             all[p.dest].push_back(pp);
-            out.push_back(move(pp));
+            out.push_back(std::move(pp));
         }
     }
 
     if (!s.reports_eod.empty()) {
         path pp = append(p, CharReach(), p.dest);
         all[p.dest].push_back(pp);
-        out.push_back(move(pp));
+        out.push_back(std::move(pp));
     }
 
     flat_map<u32, CharReach> dest;
@@ -155,7 +155,7 @@ void extend(const raw_dfa &rdfa, const vector<CharReach> &rev_map,
         DEBUG_PRINTF("----good: [%s] -> %u\n",
                      describeClasses(pp.reach).c_str(), pp.dest);
         all[e.first].push_back(pp);
-        out.push_back(move(pp));
+        out.push_back(std::move(pp));
     }
 }
 
@@ -172,7 +172,7 @@ vector<vector<CharReach>> generate_paths(const raw_dfa &rdfa,
             extend(rdfa, rev_map, p, all, next_gen);
         }
 
-        paths = move(next_gen);
+        paths = std::move(next_gen);
     }
 
     dump_paths(paths);

--- a/src/nfa/goughcompile.cpp
+++ b/src/nfa/goughcompile.cpp
@@ -1300,7 +1300,7 @@ unique_ptr<raw_report_info> gough_build_strat::gatherReports(
     *arbReport = MO_INVALID_IDX;
     assert(!ri->rl.empty()); /* all components should be able to generate
                                 reports */
-    return move(ri);
+    return std::move(ri);
 }
 
 u32 raw_gough_report_info_impl::getReportListSize() const {

--- a/src/nfa/limex_compile.cpp
+++ b/src/nfa/limex_compile.cpp
@@ -1026,7 +1026,7 @@ u32 addReports(const flat_set<ReportID> &r, vector<ReportID> &reports,
 
     u32 offset = verify_u32(reports.size());
     insert(&reports, reports.end(), my_reports);
-    reports_cache.emplace(move(my_reports), offset);
+    reports_cache.emplace(std::move(my_reports), offset);
     return offset;
 }
 
@@ -1064,7 +1064,7 @@ void buildAcceptsList(const build_info &args, ReportListCache &reports_cache,
             a.reports = addReports(h[v].reports, reports, reports_cache);
         }
         a.squash = addSquashMask(args, v, squash);
-        accepts.push_back(move(a));
+        accepts.push_back(std::move(a));
     }
 }
 
@@ -1819,7 +1819,7 @@ struct Factory {
             *streamState += streamStateLen;
             *scratchStateSize += sizeof(RepeatControl);
 
-            out.emplace_back(move(info));
+            out.emplace_back(std::move(info));
         }
     }
 

--- a/src/nfa/mcclellancompile.cpp
+++ b/src/nfa/mcclellancompile.cpp
@@ -463,7 +463,7 @@ unique_ptr<raw_report_info> mcclellan_build_strat::gatherReports(
         *isSingleReport = 0;
     }
 
-    return move(ri);
+    return std::move(ri);
 }
 
 u32 raw_report_info_impl::getReportListSize() const {

--- a/src/nfa/rdfa_merge.cpp
+++ b/src/nfa/rdfa_merge.cpp
@@ -320,7 +320,7 @@ void mergeDfas(vector<unique_ptr<raw_dfa>> &dfas, size_t max_states,
 
     queue<unique_ptr<raw_dfa>> q;
     for (auto &dfa : dfas) {
-        q.push(move(dfa));
+        q.push(std::move(dfa));
     }
 
     // All DFAs are now on the queue, so we'll clear the vector and use it for
@@ -329,30 +329,30 @@ void mergeDfas(vector<unique_ptr<raw_dfa>> &dfas, size_t max_states,
 
     while (q.size() > 1) {
         // Attempt to merge the two front elements of the queue.
-        unique_ptr<raw_dfa> d1 = move(q.front());
+        unique_ptr<raw_dfa> d1 = std::move(q.front());
         q.pop();
-        unique_ptr<raw_dfa> d2 = move(q.front());
+        unique_ptr<raw_dfa> d2 = std::move(q.front());
         q.pop();
 
         auto rdfa = mergeTwoDfas(d1.get(), d2.get(), max_states, rm, grey);
         if (rdfa) {
-            q.push(move(rdfa));
+            q.push(std::move(rdfa));
         } else {
             DEBUG_PRINTF("failed to merge\n");
             // Put the larger of the two DFAs on the output list, retain the
             // smaller one on the queue for further merge attempts.
             if (d2->states.size() > d1->states.size()) {
-                dfas.push_back(move(d2));
-                q.push(move(d1));
+                dfas.push_back(std::move(d2));
+                q.push(std::move(d1));
             } else {
-                dfas.push_back(move(d1));
-                q.push(move(d2));
+                dfas.push_back(std::move(d1));
+                q.push(std::move(d2));
             }
         }
     }
 
     while (!q.empty()) {
-        dfas.push_back(move(q.front()));
+        dfas.push_back(std::move(q.front()));
         q.pop();
     }
 

--- a/src/nfa/shengcompile.cpp
+++ b/src/nfa/shengcompile.cpp
@@ -271,7 +271,7 @@ unique_ptr<raw_report_info> sheng_build_strat::gatherReports(
         *isSingleReport = 0;
     }
 
-    return move(ri);
+    return std::move(ri);
 }
 
 u32 sheng_build_strat::max_allowed_offset_accel() const {

--- a/src/nfagraph/ng_builder.cpp
+++ b/src/nfagraph/ng_builder.cpp
@@ -163,7 +163,7 @@ BuiltExpression NFABuilderImpl::getGraph() {
         throw CompileError("Pattern too large.");
     }
 
-    return { expr, move(graph) };
+    return { expr, std::move(graph) };
 }
 
 void NFABuilderImpl::setNodeReportID(Position pos, int offsetAdjust) {

--- a/src/nfagraph/ng_calc_components.cpp
+++ b/src/nfagraph/ng_calc_components.cpp
@@ -370,7 +370,7 @@ void splitIntoComponents(unique_ptr<NGHolder> g,
         pruneUseless(*gc);
         DEBUG_PRINTF("component %zu has %zu vertices\n", comps.size(),
                      num_vertices(*gc));
-        comps.push_back(move(gc));
+        comps.push_back(std::move(gc));
     }
 
     // Another component to handle the direct shell-to-shell edges.
@@ -386,7 +386,7 @@ void splitIntoComponents(unique_ptr<NGHolder> g,
         pruneUseless(*gc);
         DEBUG_PRINTF("shell edge component %zu has %zu vertices\n",
                      comps.size(), num_vertices(*gc));
-        comps.push_back(move(gc));
+        comps.push_back(std::move(gc));
         *shell_comp = true;
     }
 

--- a/src/nfagraph/ng_equivalence.cpp
+++ b/src/nfagraph/ng_equivalence.cpp
@@ -350,7 +350,7 @@ vector<VertexInfoSet> partitionGraph(vector<unique_ptr<VertexInfo>> &infos,
             unsigned eq_class = classes.size();
             vi->equivalence_class = eq_class;
             classes.push_back({vi.get()});
-            classinfomap.emplace(move(ci), eq_class);
+            classinfomap.emplace(std::move(ci), eq_class);
         } else {
             // vertex is added to an existing class.
             unsigned eq_class = ii->second;
@@ -442,7 +442,7 @@ void equivalence(vector<VertexInfoSet> &classes, WorkQueue &work_queue,
                     classes[cur_class].erase(vi);
                     new_class_vertices.insert(vi);
                 }
-                classes.push_back(move(new_class_vertices));
+                classes.push_back(std::move(new_class_vertices));
 
                 if (contains(tmi->first, cur_class)) {
                     reval_queue.push(new_class);

--- a/src/nfagraph/ng_limex_accel.cpp
+++ b/src/nfagraph/ng_limex_accel.cpp
@@ -254,7 +254,7 @@ void findBestInternal(vector<vector<CharReach>>::const_iterator pb,
             DEBUG_PRINTF("worse\n");
             continue;
         }
-        priority_path.push_back(move(as));
+        priority_path.push_back(std::move(as));
     }
 
     sort(priority_path.begin(), priority_path.end());
@@ -422,7 +422,7 @@ void findDoubleBest(vector<vector<CharReach> >::const_iterator pb,
             DEBUG_PRINTF("worse\n");
             continue;
         }
-        priority_path.push_back(move(as));
+        priority_path.push_back(std::move(as));
     }
 
     sort(priority_path.begin(), priority_path.end());
@@ -569,7 +569,7 @@ AccelScheme findBestAccelScheme(vector<vector<CharReach>> paths,
         DAccelScheme da = findBestDoubleAccelScheme(paths, terminating);
         if (da.double_byte.size() <= DOUBLE_SHUFTI_LIMIT) {
             rv.double_byte = std::move(da.double_byte);
-            rv.double_cr = move(da.double_cr);
+            rv.double_cr = std::move(da.double_cr);
             rv.double_offset = da.double_offset;
         }
     }

--- a/src/nfagraph/ng_literal_analysis.cpp
+++ b/src/nfagraph/ng_literal_analysis.cpp
@@ -67,7 +67,7 @@ namespace {
 
 struct LitGraphVertexProps {
     LitGraphVertexProps() = default;
-    explicit LitGraphVertexProps(ue2_literal::elem c_in) : c(move(c_in)) {}
+    explicit LitGraphVertexProps(ue2_literal::elem c_in) : c(std::move(c_in)) {}
     ue2_literal::elem c; // string element (char + bool)
     size_t index = 0; // managed by ue2_graph
 };

--- a/src/nfagraph/ng_literal_decorated.cpp
+++ b/src/nfagraph/ng_literal_decorated.cpp
@@ -238,7 +238,7 @@ bool handleDecoratedLiterals(RoseBuild &rose, const NGHolder &g,
             DEBUG_PRINTF("failed validation\n");
             return false;
         }
-        masks.push_back(move(pm));
+        masks.push_back(std::move(pm));
     }
 
     for (const auto &pm : masks) {

--- a/src/nfagraph/ng_region.cpp
+++ b/src/nfagraph/ng_region.cpp
@@ -100,7 +100,7 @@ void checkAndAddExitCandidate(const AcyclicGraph &g,
 
     if (!open.empty()) {
         DEBUG_PRINTF("exit %zu\n", g[v].index);
-        exits.push_back(move(v_exit));
+        exits.push_back(std::move(v_exit));
     }
 }
 
@@ -210,7 +210,7 @@ void buildInitialCandidate(const AcyclicGraph &g,
 
     if (it != ite) {
         enters.erase(*it);
-        open_jumps = move(enters);
+        open_jumps = std::move(enters);
         DEBUG_PRINTF("oj size = %zu\n", open_jumps.size());
         ++it;
     } else {

--- a/src/nfagraph/ng_som.cpp
+++ b/src/nfagraph/ng_som.cpp
@@ -1734,7 +1734,7 @@ void clearProperInEdges(NGHolder &g, const NFAVertex sink) {
 namespace {
 struct SomRevNfa {
     SomRevNfa(NFAVertex s, ReportID r, bytecode_ptr<NFA> n)
-        : sink(s), report(r), nfa(move(n)) {}
+        : sink(s), report(r), nfa(std::move(n)) {}
     NFAVertex sink;
     ReportID report;
     bytecode_ptr<NFA> nfa;
@@ -1800,7 +1800,7 @@ bool makeSomRevNfa(vector<SomRevNfa> &som_nfas, const NGHolder &g,
         return false;
     }
 
-    som_nfas.emplace_back(sink, report, move(nfa));
+    som_nfas.emplace_back(sink, report, std::move(nfa));
     return true;
 }
 
@@ -1840,7 +1840,7 @@ bool doSomRevNfa(NG &ng, NGHolder &g, const CompileContext &cc) {
         assert(som_nfa.nfa);
 
         // Transfer ownership of the NFA to the SOM slot manager.
-        u32 comp_id = ng.ssm.addRevNfa(move(som_nfa.nfa), maxWidth);
+        u32 comp_id = ng.ssm.addRevNfa(std::move(som_nfa.nfa), maxWidth);
 
         // Replace this report on 'g' with a SOM_REV_NFA report pointing at our
         // new component.
@@ -1873,7 +1873,7 @@ u32 doSomRevNfaPrefix(NG &ng, const ExpressionInfo &expr, NGHolder &g,
                max(cc.grey.maxHistoryAvailable, ng.maxSomRevHistoryAvailable));
     }
 
-    return ng.ssm.addRevNfa(move(nfa), maxWidth);
+    return ng.ssm.addRevNfa(std::move(nfa), maxWidth);
 }
 
 static

--- a/src/nfagraph/ng_violet.cpp
+++ b/src/nfagraph/ng_violet.cpp
@@ -394,7 +394,7 @@ void getSimpleRoseLiterals(const NGHolder &g, bool seeking_anchored,
 
     lits->reserve(lit_info.size());
     for (auto &m : lit_info) {
-        lits->push_back(move(m.second));
+        lits->push_back(std::move(m.second));
     }
     DEBUG_PRINTF("%zu candidate literal sets\n", lits->size());
 }
@@ -707,11 +707,11 @@ unique_ptr<VertLitInfo> findBestSplit(const NGHolder &g,
     auto cmp = LitComparator(g, seeking_anchored, seeking_transient,
                              last_chance);
 
-    unique_ptr<VertLitInfo> best = move(lits.back());
+    unique_ptr<VertLitInfo> best = std::move(lits.back());
     lits.pop_back();
     while (!lits.empty()) {
         if (cmp(best, lits.back())) {
-            best = move(lits.back());
+            best = std::move(lits.back());
         }
         lits.pop_back();
     }
@@ -1621,7 +1621,7 @@ void removeRedundantLiteralsFromPrefixes(RoseInGraph &g,
         if (delay && delay != MO_INVALID_IDX) {
             DEBUG_PRINTF("setting delay %u on lhs %p\n", delay, h.get());
 
-            g[e].graph = move(h);
+            g[e].graph = std::move(h);
             g[e].graph_lag = delay;
         }
     }

--- a/src/parser/ComponentAlternation.cpp
+++ b/src/parser/ComponentAlternation.cpp
@@ -103,7 +103,7 @@ void ComponentAlternation::accept(ConstComponentVisitor &v) const {
 }
 
 void ComponentAlternation::append(unique_ptr<Component> component) {
-    children.push_back(move(component));
+    children.push_back(std::move(component));
 }
 
 vector<PositionInfo> ComponentAlternation::first() const {

--- a/src/parser/ComponentCondReference.cpp
+++ b/src/parser/ComponentCondReference.cpp
@@ -50,7 +50,7 @@ ComponentCondReference::ComponentCondReference(const string &name)
     : kind(CONDITION_NAME), ref_id(0), ref_name(name), hasBothBranches(false) {}
 
 ComponentCondReference::ComponentCondReference(unique_ptr<Component> c)
-    : kind(CONDITION_ASSERTION), ref_id(0), assertion(move(c)),
+    : kind(CONDITION_ASSERTION), ref_id(0), assertion(std::move(c)),
       hasBothBranches(false) {}
 
 ComponentCondReference::~ComponentCondReference() {}

--- a/src/parser/ComponentRepeat.cpp
+++ b/src/parser/ComponentRepeat.cpp
@@ -61,7 +61,7 @@ static constexpr u32 MAX_POSITIONS_EXPANDED = 500000; // arbitrarily huge
  * extent is effectively zero. */
 ComponentRepeat::ComponentRepeat(unique_ptr<Component> sub_comp_in, u32 min,
                                  u32 max, enum RepeatType t)
-    : type(t), sub_comp(move(sub_comp_in)), m_min(min), m_max(max),
+    : type(t), sub_comp(std::move(sub_comp_in)), m_min(min), m_max(max),
       posFirst(GlushkovBuildState::POS_UNINITIALIZED),
       posLast(GlushkovBuildState::POS_UNINITIALIZED) {
     assert(sub_comp);
@@ -362,7 +362,7 @@ void ComponentRepeat::postSubNotePositionHook() {
 unique_ptr<ComponentRepeat> makeComponentRepeat(unique_ptr<Component> sub_comp,
                                                 u32 min, u32 max,
                                                 ComponentRepeat::RepeatType t) {
-    return ue2::make_unique<ComponentRepeat>(move(sub_comp), min, max, t);
+    return ue2::make_unique<ComponentRepeat>(std::move(sub_comp), min, max, t);
 }
 
 } // namespace ue2

--- a/src/parser/ComponentSequence.cpp
+++ b/src/parser/ComponentSequence.cpp
@@ -117,7 +117,7 @@ void ComponentSequence::accept(ConstComponentVisitor &v) const {
 }
 
 void ComponentSequence::addComponent(unique_ptr<Component> comp) {
-    children.push_back(move(comp));
+    children.push_back(std::move(comp));
 }
 
 bool ComponentSequence::addRepeat(u32 min, u32 max,
@@ -132,7 +132,7 @@ bool ComponentSequence::addRepeat(u32 min, u32 max,
         return false;
     }
 
-    children.back() = makeComponentRepeat(move(children.back()), min, max,
+    children.back() = makeComponentRepeat(std::move(children.back()), min, max,
                                           type);
     assert(children.back());
     return true;
@@ -145,14 +145,14 @@ void ComponentSequence::addAlternation() {
 
     auto seq = ue2::make_unique<ComponentSequence>();
     seq->children.swap(children);
-    alternation->append(move(seq));
+    alternation->append(std::move(seq));
 }
 
 void ComponentSequence::finalize() {
     if (alternation) {
         addAlternation();
         assert(children.empty());
-        children.push_back(move(alternation));
+        children.push_back(std::move(alternation));
         alternation = nullptr;
     }
 }

--- a/src/parser/Parser.rl
+++ b/src/parser/Parser.rl
@@ -164,7 +164,7 @@ ComponentSequence *enterSequence(ComponentSequence *parent,
     assert(child);
 
     ComponentSequence *seq = child.get();
-    parent->addComponent(move(child));
+    parent->addComponent(std::move(child));
     return seq;
 }
 
@@ -176,7 +176,7 @@ void addLiteral(ComponentSequence *currentSeq, char c, const ParseMode &mode) {
         assert(cc);
         cc->add(c);
         cc->finalize();
-        currentSeq->addComponent(move(cc));
+        currentSeq->addComponent(std::move(cc));
     } else {
         currentSeq->addComponent(getLiteralComponentClass(c, mode.caseless));
     }
@@ -191,7 +191,7 @@ void addEscaped(ComponentSequence *currentSeq, unichar accum,
         assert(cc);
         cc->add(accum);
         cc->finalize();
-        currentSeq->addComponent(move(cc));
+        currentSeq->addComponent(std::move(cc));
     } else {
         if (accum > 255) {
             throw LocatedParseError(err_msg);
@@ -330,7 +330,7 @@ unichar readUtf8CodePoint4c(const char *s) {
         PUSH_SEQUENCE;
         auto seq = ue2::make_unique<ComponentSequence>();
         seq->setCaptureIndex(groupIndex++);
-        currentSeq = enterSequence(currentSeq, move(seq));
+        currentSeq = enterSequence(currentSeq, std::move(seq));
     }
 
     # enter a NAMED CAPTURING group ( e.g. (?'<hatstand>blah) )
@@ -347,7 +347,7 @@ unichar readUtf8CodePoint4c(const char *s) {
         auto seq = ue2::make_unique<ComponentSequence>();
         seq->setCaptureIndex(groupIndex++);
         seq->setCaptureName(label);
-        currentSeq = enterSequence(currentSeq, move(seq));
+        currentSeq = enterSequence(currentSeq, std::move(seq));
     }
 
     # enter a NON-CAPTURING group where we're modifying flags
@@ -724,7 +724,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                      ([^^] ${ fhold; fcall readUCP; })
                       '}' ${ if (!inCharClass) { // not inside [..]
                                  currentCls->finalize();
-                                 currentSeq->addComponent(move(currentCls));
+                                 currentSeq->addComponent(std::move(currentCls));
                              }
                              fret; 
                            })
@@ -735,7 +735,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_C, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret; 
         };
@@ -743,7 +743,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_L, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret; 
         };
@@ -751,7 +751,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_M, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret; 
         };
@@ -759,7 +759,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_N, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret;
         };
@@ -767,7 +767,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_P, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret; 
         };
@@ -775,7 +775,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_S, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret; 
         };
@@ -783,7 +783,7 @@ unichar readUtf8CodePoint4c(const char *s) {
             currentCls->add(CLASS_UCP_Z, negated); 
             if (!inCharClass) {
                 currentCls->finalize();
-                currentSeq->addComponent(move(currentCls));
+                currentSeq->addComponent(std::move(currentCls));
             }
             fret; 
         };
@@ -1106,7 +1106,7 @@ unichar readUtf8CodePoint4c(const char *s) {
 
               ']' => {
                   currentCls->finalize();
-                  currentSeq->addComponent(move(currentCls));
+                  currentSeq->addComponent(std::move(currentCls));
                   inCharClass = false;
                   fgoto main;
               };
@@ -1163,7 +1163,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   auto cc = getComponentClass(mode);
                   cc->add(readUtf8CodePoint2c(ts));
                   cc->finalize();
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               utf8_3c when is_utf8 => {
@@ -1172,7 +1172,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   auto cc = getComponentClass(mode);
                   cc->add(readUtf8CodePoint3c(ts));
                   cc->finalize();
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               utf8_4c when is_utf8 => {
@@ -1181,7 +1181,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   auto cc = getComponentClass(mode);
                   cc->add(readUtf8CodePoint4c(ts));
                   cc->finalize();
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               hi_byte when is_utf8 => {
@@ -1618,52 +1618,52 @@ unichar readUtf8CodePoint4c(const char *s) {
               # Word character
               '\\w' => {
                   auto cc = generateComponent(CLASS_WORD, false, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Non word character
               '\\W' => {
                   auto cc = generateComponent(CLASS_WORD, true, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Whitespace character
               '\\s' => {
                   auto cc = generateComponent(CLASS_SPACE, false, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Non whitespace character
               '\\S' => {
                   auto cc = generateComponent(CLASS_SPACE, true, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Digit character
               '\\d' => {
                   auto cc = generateComponent(CLASS_DIGIT, false, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Non digit character
               '\\D' => {
                   auto cc = generateComponent(CLASS_DIGIT, true, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Horizontal whitespace
               '\\h' => {
                   auto cc = generateComponent(CLASS_HORZ, false, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Not horizontal whitespace
               '\\H' => {
                   auto cc = generateComponent(CLASS_HORZ, true, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Vertical whitespace
               '\\v' => {
                   auto cc = generateComponent(CLASS_VERT, false, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
               # Not vertical whitespace
               '\\V' => {
                   auto cc = generateComponent(CLASS_VERT, true, mode);
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               '\\p{' => {
@@ -1787,7 +1787,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   ComponentAssertion *a_seq = a.get();
                   PUSH_SEQUENCE;
                   currentSeq = enterSequence(currentSeq,
-                        ue2::make_unique<ComponentCondReference>(move(a)));
+                        ue2::make_unique<ComponentCondReference>(std::move(a)));
                   PUSH_SEQUENCE;
                   currentSeq = a_seq;
               };
@@ -1798,7 +1798,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   ComponentAssertion *a_seq = a.get();
                   PUSH_SEQUENCE;
                   currentSeq = enterSequence(currentSeq,
-                        ue2::make_unique<ComponentCondReference>(move(a)));
+                        ue2::make_unique<ComponentCondReference>(std::move(a)));
                   PUSH_SEQUENCE;
                   currentSeq = a_seq;
               };
@@ -1809,7 +1809,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   ComponentAssertion *a_seq = a.get();
                   PUSH_SEQUENCE;
                   currentSeq = enterSequence(currentSeq,
-                        ue2::make_unique<ComponentCondReference>(move(a)));
+                        ue2::make_unique<ComponentCondReference>(std::move(a)));
                   PUSH_SEQUENCE;
                   currentSeq = a_seq;
               };
@@ -1820,7 +1820,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   ComponentAssertion *a_seq = a.get();
                   PUSH_SEQUENCE;
                   currentSeq = enterSequence(currentSeq,
-                        ue2::make_unique<ComponentCondReference>(move(a)));
+                        ue2::make_unique<ComponentCondReference>(std::move(a)));
                   PUSH_SEQUENCE;
                   currentSeq = a_seq;
               };
@@ -1861,7 +1861,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   auto cc = getComponentClass(mode);
                   cc->add(readUtf8CodePoint2c(ts));
                   cc->finalize();
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               utf8_3c when is_utf8 => {
@@ -1870,7 +1870,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   auto cc = getComponentClass(mode);
                   cc->add(readUtf8CodePoint3c(ts));
                   cc->finalize();
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               utf8_4c when is_utf8 => {
@@ -1879,7 +1879,7 @@ unichar readUtf8CodePoint4c(const char *s) {
                   auto cc = getComponentClass(mode);
                   cc->add(readUtf8CodePoint4c(ts));
                   cc->finalize();
-                  currentSeq->addComponent(move(cc));
+                  currentSeq->addComponent(std::move(cc));
               };
 
               hi_byte when is_utf8 => {
@@ -2024,7 +2024,7 @@ unique_ptr<Component> parse(const char *ptr, ParseMode &globalMode) {
         // Ensure that all references are valid.
         checkReferences(*rootSeq, groupIndex, groupNames);
 
-        return move(rootSeq);
+        return std::move(rootSeq);
     } catch (LocatedParseError &error) {
         if (ts >= ptr && ts <= pe) {
             error.locate(ts - ptr);

--- a/src/rose/rose_build_add.cpp
+++ b/src/rose/rose_build_add.cpp
@@ -1781,7 +1781,7 @@ bool RoseBuildImpl::addOutfix(const NGHolder &h) {
     }
 
     if (rdfa) {
-        outfixes.push_back(OutfixInfo(move(rdfa)));
+        outfixes.push_back(OutfixInfo(std::move(rdfa)));
     } else {
         outfixes.push_back(OutfixInfo(cloneHolder(h)));
     }

--- a/src/rose/rose_build_anchored.cpp
+++ b/src/rose/rose_build_anchored.cpp
@@ -145,9 +145,9 @@ void mergeAnchoredDfas(vector<unique_ptr<raw_dfa>> &dfas,
     for (auto &rdfa : dfas) {
         u32 start_size = mcclellanStartReachSize(rdfa.get());
         if (start_size <= MAX_SMALL_START_REACH) {
-            small_starts.push_back(move(rdfa));
+            small_starts.push_back(std::move(rdfa));
         } else {
-            big_starts.push_back(move(rdfa));
+            big_starts.push_back(std::move(rdfa));
         }
     }
     dfas.clear();
@@ -159,10 +159,10 @@ void mergeAnchoredDfas(vector<unique_ptr<raw_dfa>> &dfas,
 
     // Rehome our groups into one vector.
     for (auto &rdfa : small_starts) {
-        dfas.push_back(move(rdfa));
+        dfas.push_back(std::move(rdfa));
     }
     for (auto &rdfa : big_starts) {
-        dfas.push_back(move(rdfa));
+        dfas.push_back(std::move(rdfa));
     }
 
     // Final test: if we've built two DFAs here that are small enough, we can
@@ -686,7 +686,7 @@ int finalise_out(RoseBuildImpl &build, const NGHolder &h,
     if (check_dupe(*out_dfa, build.anchored_nfas[hash], remap)) {
         return ANCHORED_REMAP;
     }
-    build.anchored_nfas[hash].push_back(move(out_dfa));
+    build.anchored_nfas[hash].push_back(std::move(out_dfa));
     return ANCHORED_SUCCESS;
 }
 
@@ -701,7 +701,7 @@ int addAutomaton(RoseBuildImpl &build, const NGHolder &h, ReportID *remap) {
 
     auto out_dfa = ue2::make_unique<raw_dfa>(NFA_OUTFIX_RAW);
     if (determinise(autom, out_dfa->states, MAX_DFA_STATES)) {
-        return finalise_out(build, h, autom, move(out_dfa), remap);
+        return finalise_out(build, h, autom, std::move(out_dfa), remap);
     }
 
     DEBUG_PRINTF("determinise failed\n");
@@ -768,7 +768,7 @@ void buildSimpleDfas(const RoseBuildImpl &build, const vector<u32> &frag_map,
         rdfa->start_floating = DEAD_STATE;
         rdfa->alpha_size = autom.alphasize;
         rdfa->alpha_remap = autom.alpha;
-        anchored_dfas->push_back(move(rdfa));
+        anchored_dfas->push_back(std::move(rdfa));
     }
 }
 
@@ -785,7 +785,7 @@ vector<unique_ptr<raw_dfa>> getAnchoredDfas(RoseBuildImpl &build,
     // DFAs that already exist as raw_dfas.
     for (auto &anch_dfas : build.anchored_nfas) {
         for (auto &rdfa : anch_dfas.second) {
-            dfas.push_back(move(rdfa));
+            dfas.push_back(std::move(rdfa));
         }
     }
     build.anchored_nfas.clear();
@@ -835,7 +835,7 @@ size_t buildNfas(vector<raw_dfa> &anchored_dfas,
 
         assert(nfa->length);
         total_size += ROUNDUP_CL(sizeof(anchored_matcher_info) + nfa->length);
-        nfas->push_back(move(nfa));
+        nfas->push_back(std::move(nfa));
     }
 
     // We no longer need to keep the raw_dfa structures around.
@@ -862,7 +862,7 @@ vector<raw_dfa> buildAnchoredDfas(RoseBuildImpl &build,
     dfas.reserve(anch_dfas.size());
     for (auto &rdfa : anch_dfas) {
         assert(rdfa);
-        dfas.push_back(move(*rdfa));
+        dfas.push_back(std::move(*rdfa));
     }
     return dfas;
 }

--- a/src/rose/rose_build_bytecode.cpp
+++ b/src/rose/rose_build_bytecode.cpp
@@ -702,9 +702,9 @@ buildSuffix(const ReportManager &rm, const SomSlotManager &ssm,
                 auto d = getDfa(*rdfa, false, cc, rm);
                 assert(d);
                 if (cc.grey.roseMcClellanSuffix != 2) {
-                    n = pickImpl(move(d), move(n), fast_nfa);
+                    n = pickImpl(std::move(d), std::move(n), fast_nfa);
                 } else {
-                    n = move(d);
+                    n = std::move(d);
                 }
 
                 assert(n);
@@ -854,7 +854,7 @@ bytecode_ptr<NFA> makeLeftNfa(const RoseBuildImpl &tbi, left_id &left,
         if (rdfa) {
             auto d = getDfa(*rdfa, is_transient, cc, rm);
             assert(d);
-            n = pickImpl(move(d), move(n), fast_nfa);
+            n = pickImpl(std::move(d), std::move(n), fast_nfa);
         }
     }
 
@@ -1423,12 +1423,12 @@ void buildExclusiveInfixes(RoseBuildImpl &build, build_context &bc,
             setLeftNfaProperties(*n, leftfix);
 
             ExclusiveSubengine engine;
-            engine.nfa = move(n);
+            engine.nfa = std::move(n);
             engine.vertices = verts;
-            info.subengines.push_back(move(engine));
+            info.subengines.push_back(std::move(engine));
         }
         info.queue = qif.get_queue();
-        exclusive_info.push_back(move(info));
+        exclusive_info.push_back(std::move(info));
     }
     updateExclusiveInfixProperties(build, exclusive_info, bc.leftfix_info,
                                    no_retrigger_queues);
@@ -1650,7 +1650,7 @@ public:
             if (rdfa) {
                 auto d = getDfa(*rdfa, false, cc, rm);
                 if (d) {
-                    n = pickImpl(move(d), move(n), fast_nfa);
+                    n = pickImpl(std::move(d), std::move(n), fast_nfa);
                 }
             }
         }
@@ -1865,15 +1865,15 @@ void buildExclusiveSuffixes(RoseBuildImpl &build, build_context &bc,
             setSuffixProperties(*n, s, build.rm);
 
             ExclusiveSubengine engine;
-            engine.nfa = move(n);
+            engine.nfa = std::move(n);
             engine.vertices = verts;
-            info.subengines.push_back(move(engine));
+            info.subengines.push_back(std::move(engine));
 
             const auto &reports = all_reports(s);
             info.reports.insert(reports.begin(), reports.end());
         }
         info.queue = qif.get_queue();
-        exclusive_info.push_back(move(info));
+        exclusive_info.push_back(std::move(info));
     }
     updateExclusiveSuffixProperties(build, exclusive_info,
                                     no_retrigger_queues);
@@ -2417,7 +2417,7 @@ u32 writeProgram(build_context &bc, RoseProgram &&program) {
     u32 offset = bc.engine_blob.add(prog_bytecode);
     DEBUG_PRINTF("prog len %zu written at offset %u\n", prog_bytecode.size(),
                  offset);
-    bc.program_cache.emplace(move(program), offset);
+    bc.program_cache.emplace(std::move(program), offset);
     return offset;
 }
 
@@ -2582,13 +2582,13 @@ void makeBoundaryPrograms(const RoseBuildImpl &build, build_context &bc,
     DEBUG_PRINTF("report ^$: %zu\n", dboundary.report_at_0_eod_full.size());
 
     auto eod_prog = makeBoundaryProgram(build, boundary.report_at_eod);
-    out.reportEodOffset = writeProgram(bc, move(eod_prog));
+    out.reportEodOffset = writeProgram(bc, std::move(eod_prog));
 
     auto zero_prog = makeBoundaryProgram(build, boundary.report_at_0);
-    out.reportZeroOffset = writeProgram(bc, move(zero_prog));
+    out.reportZeroOffset = writeProgram(bc, std::move(zero_prog));
 
     auto zeod_prog = makeBoundaryProgram(build, dboundary.report_at_0_eod_full);
-    out.reportZeroEodOffset = writeProgram(bc, move(zeod_prog));
+    out.reportZeroEodOffset = writeProgram(bc, std::move(zeod_prog));
 }
 
 static
@@ -2753,10 +2753,10 @@ RoseProgram makeFragmentProgram(const RoseBuildImpl &build, build_context &bc,
     for (const auto &lit_id : lit_ids) {
         auto prog = makeLiteralProgram(build, bc, prog_build, lit_id,
                                        lit_edge_map, false);
-        blocks.push_back(move(prog));
+        blocks.push_back(std::move(prog));
     }
 
-    return assembleProgramBlocks(move(blocks));
+    return assembleProgramBlocks(std::move(blocks));
 }
 
 /**
@@ -2866,7 +2866,7 @@ vector<LitFragment> groupByFragment(const RoseBuildImpl &build) {
         auto &fi = m.second;
         DEBUG_PRINTF("frag %s -> ids: %s\n", dumpString(m.first.s).c_str(),
                      as_string_list(fi.lit_ids).c_str());
-        fragments.emplace_back(frag_id, lit.s, fi.groups, move(fi.lit_ids));
+        fragments.emplace_back(frag_id, lit.s, fi.groups, std::move(fi.lit_ids));
         frag_id++;
         assert(frag_id == fragments.size());
     }
@@ -2982,7 +2982,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
                          child_offset);
             addIncludedJumpProgram(lit_prog, child_offset, pfrag.squash);
         }
-        pfrag.lit_program_offset = writeProgram(bc, move(lit_prog));
+        pfrag.lit_program_offset = writeProgram(bc, std::move(lit_prog));
 
         // We only do delayed rebuild in streaming mode.
         if (!build.cc.streaming) {
@@ -3002,7 +3002,7 @@ void buildFragmentPrograms(const RoseBuildImpl &build,
             addIncludedJumpProgram(rebuild_prog, child_offset,
                                    pfrag.delay_squash);
         }
-        pfrag.delay_program_offset = writeProgram(bc, move(rebuild_prog));
+        pfrag.delay_program_offset = writeProgram(bc, std::move(rebuild_prog));
     }
 }
 
@@ -3091,7 +3091,7 @@ pair<u32, u32> writeDelayPrograms(const RoseBuildImpl &build,
                 auto prog = makeLiteralProgram(build, bc, prog_build,
                                                delayed_lit_id, lit_edge_map,
                                                false);
-                u32 offset = writeProgram(bc, move(prog));
+                u32 offset = writeProgram(bc, std::move(prog));
 
                 u32 delay_id;
                 auto it = cache.find(offset);
@@ -3151,7 +3151,7 @@ pair<u32, u32> writeAnchoredPrograms(const RoseBuildImpl &build,
 
             auto prog = makeLiteralProgram(build, bc, prog_build, lit_id,
                                            lit_edge_map, true);
-            u32 offset = writeProgram(bc, move(prog));
+            u32 offset = writeProgram(bc, std::move(prog));
             DEBUG_PRINTF("lit_id=%u -> anch prog at %u\n", lit_id, offset);
 
             u32 anch_id;
@@ -3211,7 +3211,7 @@ pair<u32, u32> buildReportPrograms(const RoseBuildImpl &build,
 
     for (ReportID id : reports) {
         auto program = makeReportProgram(build, bc.needs_mpv_catchup, id);
-        u32 offset = writeProgram(bc, move(program));
+        u32 offset = writeProgram(bc, std::move(program));
         programs.push_back(offset);
         build.rm.setProgramOffset(id, offset);
         DEBUG_PRINTF("program for report %u @ %u (%zu instructions)\n", id,
@@ -3327,7 +3327,7 @@ void addEodEventProgram(const RoseBuildImpl &build, build_context &bc,
                                     bc.roleStateIndices, prog_build,
                                     build.eod_event_literal_id, edge_list,
                                     false);
-    program.add_block(move(block));
+    program.add_block(std::move(block));
 }
 
 static
@@ -3716,7 +3716,7 @@ bytecode_ptr<RoseEngine> RoseBuildImpl::buildFinalEngine(u32 minWidth) {
                          drproto.get(), eproto.get(), sbproto.get());
 
     auto eod_prog = makeEodProgram(*this, bc, prog_build, eodNfaIterOffset);
-    proto.eodProgramOffset = writeProgram(bc, move(eod_prog));
+    proto.eodProgramOffset = writeProgram(bc, std::move(eod_prog));
 
     size_t longLitStreamStateRequired = 0;
     proto.longLitTableOffset
@@ -3735,11 +3735,11 @@ bytecode_ptr<RoseEngine> RoseBuildImpl::buildFinalEngine(u32 minWidth) {
     writeLogicalInfo(rm, bc.engine_blob, proto);
 
     auto flushComb_prog = makeFlushCombProgram(proto);
-    proto.flushCombProgramOffset = writeProgram(bc, move(flushComb_prog));
+    proto.flushCombProgramOffset = writeProgram(bc, std::move(flushComb_prog));
 
     auto lastFlushComb_prog = makeLastFlushCombProgram(proto);
     proto.lastFlushCombProgramOffset =
-        writeProgram(bc, move(lastFlushComb_prog));
+        writeProgram(bc, std::move(lastFlushComb_prog));
 
     // Build anchored matcher.
     auto atable = buildAnchoredMatcher(*this, fragments, anchored_dfas);
@@ -3883,7 +3883,7 @@ bytecode_ptr<RoseEngine> RoseBuildImpl::buildFinalEngine(u32 minWidth) {
     bc.engine_blob.write_bytes(engine.get());
 
     // Add a small write engine if appropriate.
-    engine = addSmallWriteEngine(*this, bc.resources, move(engine));
+    engine = addSmallWriteEngine(*this, bc.resources, std::move(engine));
 
     DEBUG_PRINTF("rose done %p\n", engine.get());
 

--- a/src/rose/rose_build_compile.cpp
+++ b/src/rose/rose_build_compile.cpp
@@ -1782,7 +1782,7 @@ bytecode_ptr<RoseEngine> RoseBuildImpl::buildRose(u32 minWidth) {
 
     /* transfer mpv outfix to main queue */
     if (mpv_outfix) {
-        outfixes.push_back(move(*mpv_outfix));
+        outfixes.push_back(std::move(*mpv_outfix));
         mpv_outfix = nullptr;
     }
 

--- a/src/rose/rose_build_convert.cpp
+++ b/src/rose/rose_build_convert.cpp
@@ -213,7 +213,7 @@ void convertFloodProneSuffix(RoseBuildImpl &tbi, RoseVertex v, u32 lit_id,
 
     // Apply the NFA.
     assert(!g[v].suffix);
-    g[v].suffix.graph = move(h);
+    g[v].suffix.graph = std::move(h);
     g[v].reports.clear();
 
     // Swap v's literal for a shorter one.

--- a/src/rose/rose_build_lookaround.cpp
+++ b/src/rose/rose_build_lookaround.cpp
@@ -464,7 +464,7 @@ void findFloodReach(const RoseBuildImpl &tbi, const RoseVertex v,
 namespace {
 struct LookProto {
     LookProto(s32 offset_in, CharReach reach_in)
-        : offset(offset_in), reach(move(reach_in)) {}
+        : offset(offset_in), reach(std::move(reach_in)) {}
     s32 offset;
     CharReach reach;
 };

--- a/src/rose/rose_build_matchers.cpp
+++ b/src/rose/rose_build_matchers.cpp
@@ -739,7 +739,7 @@ void addFragmentLiteral(const RoseBuildImpl &build, MatcherProto &mp,
 
     const auto &groups = f.groups;
 
-    mp.lits.emplace_back(move(s_final), nocase, noruns, f.fragment_id,
+    mp.lits.emplace_back(std::move(s_final), nocase, noruns, f.fragment_id,
                          groups, msk, cmp);
 }
 
@@ -937,7 +937,7 @@ buildFloatingMatcherProto(const RoseBuildImpl &build,
         throw CompileError("Unable to generate literal matcher proto.");
      }
 
-     return ue2::make_unique<LitProto>(move(proto), mp.accel_lits);
+     return ue2::make_unique<LitProto>(std::move(proto), mp.accel_lits);
 }
 
 unique_ptr<LitProto>
@@ -965,7 +965,7 @@ buildDelayRebuildMatcherProto(const RoseBuildImpl &build,
         throw CompileError("Unable to generate literal matcher proto.");
     }
 
-    return ue2::make_unique<LitProto>(move(proto), mp.accel_lits);
+    return ue2::make_unique<LitProto>(std::move(proto), mp.accel_lits);
 }
 
 unique_ptr<LitProto>
@@ -1022,7 +1022,7 @@ buildSmallBlockMatcherProto(const RoseBuildImpl &build,
         throw CompileError("Unable to generate literal matcher proto.");
     }
 
-    return ue2::make_unique<LitProto>(move(proto), mp.accel_lits);
+    return ue2::make_unique<LitProto>(std::move(proto), mp.accel_lits);
 }
 
 unique_ptr<LitProto>
@@ -1047,7 +1047,7 @@ buildEodAnchoredMatcherProto(const RoseBuildImpl &build,
         throw CompileError("Unable to generate literal matcher proto.");
     }
 
-    return ue2::make_unique<LitProto>(move(proto), mp.accel_lits);
+    return ue2::make_unique<LitProto>(std::move(proto), mp.accel_lits);
 }
 
 } // namespace ue2

--- a/src/rose/rose_build_merge.cpp
+++ b/src/rose/rose_build_merge.cpp
@@ -1454,7 +1454,7 @@ void mergeLeftfixesVariableLag(RoseBuildImpl &build) {
 
     vector<vector<left_id>> chunks;
     for (auto &raw_group : engine_groups | map_values) {
-        chunk(move(raw_group), &chunks, MERGE_GROUP_SIZE_MAX);
+        chunk(std::move(raw_group), &chunks, MERGE_GROUP_SIZE_MAX);
     }
     engine_groups.clear();
 
@@ -1523,7 +1523,7 @@ namespace {
 struct DedupeLeftKey {
     DedupeLeftKey(const RoseBuildImpl &build,
                   flat_set<pair<size_t, u32>> preds_in, const left_id &left)
-        : left_hash(hashLeftfix(left)), preds(move(preds_in)),
+        : left_hash(hashLeftfix(left)), preds(std::move(preds_in)),
           transient(contains(build.transient, left)) {
     }
 
@@ -1611,7 +1611,7 @@ void dedupeLeftfixesVariableLag(RoseBuildImpl &build) {
                 continue;
             }
         }
-        engine_groups[DedupeLeftKey(build, move(preds), left)].push_back(left);
+        engine_groups[DedupeLeftKey(build, std::move(preds), left)].push_back(left);
     }
 
     /* We don't bother chunking as we expect deduping to be successful if the
@@ -2060,7 +2060,7 @@ void mergeCastleLeftfixes(RoseBuildImpl &build) {
 
     vector<vector<left_id>> chunks;
     for (auto &raw_group : by_reach | map_values) {
-        chunk(move(raw_group), &chunks, MERGE_CASTLE_GROUP_SIZE_MAX);
+        chunk(std::move(raw_group), &chunks, MERGE_CASTLE_GROUP_SIZE_MAX);
     }
     by_reach.clear();
 
@@ -2441,7 +2441,7 @@ void pairwiseDfaMerge(vector<RawDfa *> &dfas,
             RawDfa *dfa_ptr = rdfa.get();
             dfa_mapping[dfa_ptr] = dfa_mapping[*it];
             dfa_mapping.erase(*it);
-            winner.proto = move(rdfa);
+            winner.proto = std::move(rdfa);
 
             mergeOutfixInfo(winner, victim);
 
@@ -2558,7 +2558,7 @@ void mergeOutfixCombo(RoseBuildImpl &tbi, const ReportManager &rm,
             // Transform this outfix into a DFA and add it to the merge set.
             dfa_mapping[rdfa.get()] = it - tbi.outfixes.begin();
             dfas.push_back(rdfa.get());
-            outfix.proto = move(rdfa);
+            outfix.proto = std::move(rdfa);
             new_dfas++;
         }
     }

--- a/src/rose/rose_build_program.h
+++ b/src/rose/rose_build_program.h
@@ -129,7 +129,7 @@ public:
         assert(!prog.empty());
 
         const RoseInstruction *old_ptr = it->get();
-        *it = move(ri);
+        *it = std::move(ri);
         update_targets(prog.begin(), prog.end(), old_ptr, it->get());
     }
 };

--- a/src/som/slot_manager.cpp
+++ b/src/som/slot_manager.cpp
@@ -243,7 +243,7 @@ u32 SomSlotManager::numSomSlots() const {
 
 u32 SomSlotManager::addRevNfa(bytecode_ptr<NFA> nfa, u32 maxWidth) {
     u32 rv = verify_u32(rev_nfas.size());
-    rev_nfas.push_back(move(nfa));
+    rev_nfas.push_back(std::move(nfa));
 
     // A rev nfa commits us to having enough history around to handle its
     // max width.

--- a/src/util/clique.cpp
+++ b/src/util/clique.cpp
@@ -75,7 +75,7 @@ vector<u32> findCliqueGroup(CliqueGraph &cg) {
     // Get the vertex to start from
     vector<u32> clique;
     while (!gStack.empty()) {
-        vector<u32> g = move(gStack.top());
+        vector<u32> g = std::move(gStack.top());
         gStack.pop();
 
         // Choose a vertex from the graph

--- a/tools/hsbench/engine_chimera.cpp
+++ b/tools/hsbench/engine_chimera.cpp
@@ -96,7 +96,7 @@ int HS_CDECL onMatchEcho(unsigned int id, unsigned long long,
 }
 
 EngineChimera::EngineChimera(ch_database_t *db_in, CompileCHStats cs)
-    : db(db_in), compile_stats(move(cs)) {
+    : db(db_in), compile_stats(std::move(cs)) {
     assert(db);
 }
 
@@ -333,5 +333,5 @@ buildEngineChimera(const ExpressionMap &expressions, const string &name,
     cs.compileSecs = compileSecs;
     cs.peakMemorySize = peakMemorySize;
 
-    return ue2::make_unique<EngineChimera>(db, move(cs));
+    return ue2::make_unique<EngineChimera>(db, std::move(cs));
 }

--- a/tools/hsbench/engine_hyperscan.cpp
+++ b/tools/hsbench/engine_hyperscan.cpp
@@ -175,7 +175,7 @@ unique_ptr<EngineStream> EngineHyperscan::streamOpen(EngineContext &ectx,
         return nullptr;
     }
     stream->sn = streamId;
-    return move(stream);
+    return std::move(stream);
 }
 
 void EngineHyperscan::streamClose(unique_ptr<EngineStream> stream,

--- a/tools/hsbench/engine_pcre.cpp
+++ b/tools/hsbench/engine_pcre.cpp
@@ -94,7 +94,7 @@ int onMatchEcho(unsigned int id, unsigned long long, unsigned long long to,
 
 EnginePCRE::EnginePCRE(vector<unique_ptr<PcreDB>> dbs_in, CompilePCREStats cs,
                        int capture_cnt_in)
-    : dbs(move(dbs_in)), compile_stats(move(cs)),
+    : dbs(std::move(dbs_in)), compile_stats(std::move(cs)),
       capture_cnt(capture_cnt_in) {}
 
 EnginePCRE::~EnginePCRE() {
@@ -383,7 +383,7 @@ buildEnginePcre(const ExpressionMap &expressions, const string &name,
         extra->match_limit_recursion = 1500;
 
         pcreDB->extra = extra;
-        dbs.push_back(move(pcreDB));
+        dbs.push_back(std::move(pcreDB));
     }
 
     timer.complete();
@@ -406,5 +406,5 @@ buildEnginePcre(const ExpressionMap &expressions, const string &name,
     cs.compileSecs = compileSecs;
     cs.peakMemorySize = peakMemorySize;
 
-    return ue2::make_unique<EnginePCRE>(move(dbs), move(cs), capture_cnt);
+    return ue2::make_unique<EnginePCRE>(std::move(dbs), std::move(cs), capture_cnt);
 }

--- a/tools/hsbench/main.cpp
+++ b/tools/hsbench/main.cpp
@@ -118,7 +118,7 @@ public:
                   thread_barrier &tb_in, thread_func_t function_in,
                   vector<DataBlock> corpus_data_in)
         : num(num_in), results(repeats), engine(db_in),
-          enginectx(db_in.makeContext()), corpus_data(move(corpus_data_in)),
+          enginectx(db_in.makeContext()), corpus_data(std::move(corpus_data_in)),
           tb(tb_in), function(function_in) {}
 
     // Start the thread.
@@ -235,7 +235,7 @@ void usage(const char *error) {
 /** Wraps up a name and the set of signature IDs it refers to. */
 struct BenchmarkSigs {
     BenchmarkSigs(string name_in, SignatureSet sigs_in)
-        : name(move(name_in)), sigs(move(sigs_in)) {}
+        : name(std::move(name_in)), sigs(std::move(sigs_in)) {}
     string name;
     SignatureSet sigs;
 };
@@ -473,7 +473,7 @@ void processArgs(int argc, char *argv[], vector<BenchmarkSigs> &sigSets,
     for (const auto &file : sigFiles) {
         SignatureSet sigs;
         loadSignatureList(file, sigs);
-        sigSets.emplace_back(file, move(sigs));
+        sigSets.emplace_back(file, std::move(sigs));
     }
 
     useLiteralApi = (bool)literalFlag;
@@ -606,7 +606,7 @@ void benchStreamingInternal(ThreadContext *ctx, vector<StreamInfo> &streams,
 
             // if this was the last block in the stream, close the stream handle
             if (b.id == stream.last_block_id) {
-                e.streamClose(move(stream.eng_handle), r);
+                e.streamClose(std::move(stream.eng_handle), r);
                 stream.eng_handle = nullptr;
             }
         }
@@ -1018,7 +1018,7 @@ void runBenchmark(const Engine &db,
             printf("Unable to start processing thread %u\n", i);
             exit(1);
         }
-        threads.push_back(move(t));
+        threads.push_back(std::move(t));
     }
 
     // Reap threads.
@@ -1066,7 +1066,7 @@ int HS_CDECL main(int argc, char *argv[]) {
         for (auto i : exprMapTemplate | map_keys) {
             sigs.push_back(i);
         }
-        sigSets.emplace_back(exprPath, move(sigs));
+        sigSets.emplace_back(exprPath, std::move(sigs));
     }
 
     // read in and process our corpus

--- a/tools/hscollider/GraphTruth.cpp
+++ b/tools/hscollider/GraphTruth.cpp
@@ -134,7 +134,7 @@ void CNGInfo::compile() {
             auto pl = ue2::make_unique<ParsedLogical>();
             pl->parseLogicalCombination(id, re.c_str(), ~0U, 0, ~0ULL);
             pl->logicalKeyRenumber();
-            cng = make_unique<CompiledNG>(move(pl));
+            cng = make_unique<CompiledNG>(std::move(pl));
             return;
         }
 
@@ -193,7 +193,7 @@ void CNGInfo::compile() {
             }
         }
 
-        cng = make_unique<CompiledNG>(move(g), move(rm));
+        cng = make_unique<CompiledNG>(std::move(g), std::move(rm));
     } catch (CompileError &e) {
         throw NGCompileFailure(e.reason);
     } catch (NGUnsupportedFailure &e) {

--- a/tools/hscollider/NfaGeneratedCorpora.cpp
+++ b/tools/hscollider/NfaGeneratedCorpora.cpp
@@ -107,7 +107,7 @@ void NfaGeneratedCorpora::generate(unsigned id, vector<Corpus> &data) {
             a_subid = it.first;
             vector<Corpus> sub_data;
             generate(a_subid, sub_data);
-            m_data.emplace(a_subid, move(sub_data));
+            m_data.emplace(a_subid, std::move(sub_data));
         }
         assert(!m_data.empty());
         size_t num_corpus = m_data[a_subid].size();

--- a/tools/hscollider/UltimateTruth.cpp
+++ b/tools/hscollider/UltimateTruth.cpp
@@ -1080,7 +1080,7 @@ shared_ptr<BaseDB> UltimateTruth::compile(const set<unsigned> &ids,
         }
     }
 
-    return move(db);
+    return std::move(db);
 }
 
 bool UltimateTruth::allocScratch(shared_ptr<const BaseDB> db) {

--- a/tools/hscollider/main.cpp
+++ b/tools/hscollider/main.cpp
@@ -1189,7 +1189,7 @@ struct CorpusGenUnit {
     CorpusGenUnit(unique_ptr<CNGInfo> cngi_in, unique_ptr<CompiledPcre> pcre_in,
                shared_ptr<DatabaseProxy> ue2_in, unsigned expr_id,
                bool multi_in, bool utf8_in)
-        : cngi(move(cngi_in)), pcre(move(pcre_in)), ue2(ue2_in), id(expr_id),
+        : cngi(std::move(cngi_in)), pcre(std::move(pcre_in)), ue2(ue2_in), id(expr_id),
           multi(multi_in), utf8(utf8_in) {}
 
     unique_ptr<CNGInfo> cngi;
@@ -1221,7 +1221,7 @@ public:
             }
 
             addCorporaToQueue(out, testq, c->id, *corpora, summary,
-                              move(c->pcre), move(c->cngi), c->ue2, c->multi,
+                              std::move(c->pcre), std::move(c->cngi), c->ue2, c->multi,
                               c->utf8);
 
             count++;
@@ -1435,7 +1435,7 @@ unique_ptr<CorpusGenUnit> makeCorpusGenUnit(unsigned id, TestSummary &summary,
     // Caller may already have set the UTF-8 property (in multi cases)
     utf8 |= cpcre ? cpcre->utf8 : cngi->utf8;
 
-    return ue2::make_unique<CorpusGenUnit>(move(cngi), move(cpcre), ue2, id,
+    return ue2::make_unique<CorpusGenUnit>(std::move(cngi), std::move(cpcre), ue2, id,
                                            multi, utf8);
 }
 
@@ -1490,7 +1490,7 @@ void buildSingle(BoundedQueue<CorpusGenUnit> &corpq, TestSummary &summary,
         auto u = makeCorpusGenUnit(id, summary, ground, graph, ultimate, ue2,
                                    multi, utf8);
         if (u) {
-            corpq.push(move(u));
+            corpq.push(std::move(u));
         }
     }
 }
@@ -1548,7 +1548,7 @@ void buildBanded(BoundedQueue<CorpusGenUnit> &corpq, TestSummary &summary,
             auto u = makeCorpusGenUnit(id, summary, ground, graph, ultimate,
                                        ue2, multi, utf8);
             if (u) {
-                corpq.push(move(u));
+                corpq.push(std::move(u));
             }
         }
     }
@@ -1588,7 +1588,7 @@ void buildMulti(BoundedQueue<CorpusGenUnit> &corpq, TestSummary &summary,
         auto u = makeCorpusGenUnit(id, summary, ground, graph, ultimate, ue2,
                                    multi, utf8);
         if (u) {
-            corpq.push(move(u));
+            corpq.push(std::move(u));
         }
     }
 }
@@ -1608,7 +1608,7 @@ void generateTests(CorporaSource &corpora_src, const ExpressionMap &exprMap,
     for (size_t i = 0; i < numGeneratorThreads; i++) {
         auto c = make_unique<CorpusGenThread>(i, testq, corpq, corpora_src);
         c->start();
-        generators.push_back(move(c));
+        generators.push_back(std::move(c));
     }
 
     if (g_ue2CompileAll && multicompile_bands) {
@@ -1831,11 +1831,11 @@ unique_ptr<CorporaSource> buildCorpora(const vector<string> &corporaFiles,
                 exit_with_fail();
             }
         }
-        return move(c); /* move allows unique_ptr<CorporaSource> conversion */
+        return std::move(c); /* move allows unique_ptr<CorporaSource> conversion */
     } else {
         auto c = ue2::make_unique<NfaGeneratedCorpora>(
             exprMap, corpus_gen_prop, force_utf8, force_prefilter);
-        return move(c);
+        return std::move(c);
     }
 }
 
@@ -1888,7 +1888,7 @@ bool runTests(CorporaSource &corpora_source, const ExpressionMap &exprMap,
     for (size_t i = 0; i < numScannerThreads; i++) {
         auto s = ue2::make_unique<ScanThread>(i, testq, exprMap, plat, grey);
         s->start();
-        scanners.push_back(move(s));
+        scanners.push_back(std::move(s));
     }
 
     generateTests(corpora_source, exprMap, summary, plat, grey, testq);


### PR DESCRIPTION
Clang 17 has introduced an unconditional warning on unqualified calls to `std::move` as `move` (see the [patch](https://reviews.llvm.org/D119670?id=408276)). Hyperscan has `-Werror` enabled on default compilations (which is great!) so this causes failure to compile on Clang 17+. This patch fixes all relevant calls to the qualified `std::move` instead of `move`.